### PR TITLE
Getting build working on windows

### DIFF
--- a/src/main/java/net/consensys/athena/impl/cmd/AthenaArguments.java
+++ b/src/main/java/net/consensys/athena/impl/cmd/AthenaArguments.java
@@ -56,8 +56,9 @@ public class AthenaArguments {
     System.out.println("Usage: " + Athena.name + " [options] [config file]");
     System.out.println("where options include:");
     System.out.println("\t-g");
-    System.out.println(
-        "\t--generatekeys <names>\n\t\tgenerate key pairs for each of the names supplied.\n\t\twhere <names> are a comma-seperated list");
+    System.out.println("\t--generatekeys <names>");
+    System.out.println("\t\tgenerate key pairs for each of the names supplied.");
+    System.out.println("\t\twhere <names> are a comma-seperated list");
     System.out.println("\t-h");
     System.out.println("\t--help\tprint this help message");
     System.out.println("\t-v");

--- a/src/test/java/net/consensys/athena/impl/cmd/AthenaArgumentsTest.java
+++ b/src/test/java/net/consensys/athena/impl/cmd/AthenaArgumentsTest.java
@@ -14,16 +14,17 @@ import org.junit.Test;
 public class AthenaArgumentsTest {
 
   private final String usageOut =
-      "Usage: "
-          + Athena.name
-          + " [options] [config file]\n"
-          + "where options include:\n"
-          + "\t-g\n"
-          + "\t--generatekeys <names>\n\t\tgenerate key pairs for each of the names supplied.\n\t\twhere <names> are a comma-seperated list\n"
-          + "\t-h\n"
-          + "\t--help\tprint this help message\n"
-          + "\t-v\n"
-          + "\t--version\tprint version information\n";
+      String.format(
+          "Usage: "
+              + Athena.name
+              + " [options] [config file]%n"
+              + "where options include:%n"
+              + "\t-g%n"
+              + "\t--generatekeys <names>%n\t\tgenerate key pairs for each of the names supplied.%n\t\twhere <names> are a comma-seperated list%n"
+              + "\t-h%n"
+              + "\t--help\tprint this help message%n"
+              + "\t-v%n"
+              + "\t--version\tprint version information%n");
 
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   private PrintStream originalSystemOut;
@@ -41,7 +42,7 @@ public class AthenaArgumentsTest {
 
   @Test
   public void testGenerateKeysArgumentWithNoKeyNamesProvided() {
-    String errorMsg = "Error: Missing key names to generate.\n";
+    String errorMsg = String.format("Error: Missing key names to generate.%n");
     String[] args = {"-g"};
 
     AthenaArguments arguments = new AthenaArguments(args);


### PR DESCRIPTION
UT failures occur on Windows OS, due to the new line character '\n' being used in asserting command line output.
Replaced for the String.format '%n, which provides the platform independant comparison to support both Unix & Windows line seperators.