### PR TITLE
Ignoring all the Eclipse IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
+*.db.test
+/keys.test
+/tests
 db
 routerdb
 routerdb.wal.0
 version.txt
-/keys.test
-/tests
-*.db.test
 
 
 ### Gradle ###
@@ -14,26 +14,26 @@ version.txt
 
 
 ### IntelliJ ###
+*.iml
 .idea
 build/
 out/
-*.iml
 
 
 ### Eclipse ###
-local.properties
-bin/
-target/
-tmp/
+*.bak
+*.swp
+*.tmp
+*~.nib
 .loadpath
 .metadata
 .prefs
 .recommenders
 .settings/
-*.bak
-*.swp
-*.tmp
-*~.nib
+bin/
+local.properties
+target/
+tmp/
 
 # Eclipse Core
 .project


### PR DESCRIPTION
A change set I've PR'd to Pantheon, regarding the set full set of Eclipse based IDE possible files.

You may notice that I've dropped the forward slash,  from the build directories (bin, build, target), which for the current state of Athena isn't really needed, until the path of multiple projects in the single git repo (like Pantheon) is followed.