### PR TITLE
QUOR-115: Including dependencies license checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,14 @@
 plugins {
   id "com.diffplug.gradle.spotless" version "3.6.0"
   id 'com.palantir.git-version' version '0.10.0'
+  id "com.github.hierynomus.license" version "0.14.0"
 }
 
 apply plugin: 'java-library'
 apply plugin: 'application'
 apply plugin: "jacoco"
+
+apply from: "gradle/check-licenses.gradle"
 
 mainClassName = 'net.consensys.orion.api.cmd.Orion'
 version = '0.1.0-' + versionDetails().gitHash[0..4] + '-' + getTimestamp()
@@ -19,6 +22,7 @@ applicationDefaultJvmArgs = [
 
 def buildAliases = ['dev': [
         'spotlessApply',
+        'checkLicenses',
         'build'
 ]]
 
@@ -32,7 +36,7 @@ repositories {
     jcenter()
 }
 
-// added source sets (acceptance and integratioon tests)
+// added source sets (acceptance and integration tests)
 sourceSets {
   acceptance {
     java.srcDir file('src/test-acceptance/java')

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -1,0 +1,116 @@
+/**
+ * Check that the licenses of our 3rd parties are in our acceptedLicenses list.
+ *
+ * run it with "gradle checkLicenses"
+ *
+ * To add new accepted licenses you need to update this script.
+ * Some products may be available with multiple licenses. In this case you must update
+ *  this script to add it in the downloadLicenses#licenses.
+ */
+
+// Some parts of this code comes from Zipkin/https://github.com/openzipkin/zipkin/pull/852
+// Zipkin itself is under Apache License.
+
+/**
+ * The lists of the license we accept.
+ */
+ext.acceptedLicenses = [
+        'Eclipse Public License - v 1.0',
+        'Eclipse Distribution License - v 1.0',
+        'MIT License',
+        'Apache License, Version 2.0',
+        'Bouncy Castle Licence',
+        'BSD 3-Clause'
+]*.toLowerCase()
+
+/**
+ * This is the configuration we need for our licenses plugin: 'com.github.hierynomus.license'
+ * This plugin generates a list of dependencies.
+ */
+downloadLicenses {
+    includeProjectDependencies = true
+    reportByDependency = false
+    reportByLicenseType = true
+    dependencyConfiguration = 'compileClasspath'
+
+    ext.apache = license('Apache License, Version 2.0', 'http://opensource.org/licenses/Apache-2.0')
+    ext.mit = license('MIT License', 'http://www.opensource.org/licenses/mit-license.php')
+    ext.bsd = license('BSD License', 'http://www.opensource.org/licenses/bsd-license.php')
+    ext.bsd3Clause = license('BSD 3-Clause', 'http://opensource.org/licenses/BSD-3-Clause')
+    ext.edl = license('Eclipse Distribution License - v 1.0', 'http://www.eclipse.org/org/documents/edl-v10.html')
+    ext.epl = license('Eclipse Public License - v 1.0', 'https://www.eclipse.org/legal/epl-v10.html')
+
+    aliases = [
+            (apache)    : [
+                    'The Apache Software License, Version 2.0',
+                    'Apache License Version 2.0',
+                    'Apache License, Version 2.0',
+                    'Apache 2',
+                    'Apache 2.0',
+                    'Apache License 2.0',
+                    'Apache-2.0',
+                    'ASL, version 2',
+                    license('Apache License', 'http://www.apache.org/licenses/LICENSE-2.0'),
+                    license('Apache Software Licenses', 'http://www.apache.org/licenses/LICENSE-2.0.txt'),
+                    license('Apache', 'http://www.opensource.org/licenses/Apache-2.0')
+            ],
+            (mit)       : ['The MIT License'],
+            (bsd)       : [
+                    'BSD',
+                    'Berkeley Software Distribution (BSD) License',
+                    license('New BSD License', 'http://www.opensource.org/licenses/bsd-license.php')
+            ],
+            (bsd3Clause): [
+                    'The 3-Clause BSD License',
+                    'The BSD 3-Clause License',
+                    'BSD 3-Clause',
+                    license('BSD 3-clause', 'http://opensource.org/licenses/BSD-3-Clause'),
+                    license('BSD 3-Clause', 'http://www.scala-lang.org/license.html')
+            ],
+            (edl): ['Eclipse Distribution License - v 1.0'],
+            (epl): ['Eclipse Public License - v 1.0']
+    ]
+
+    licenses = [
+            (group('orion'))                    : apache,
+            (group('net.java.dev.jna'))         : apache,
+            (group('net.jcip'))                 : apache,
+            (group('org.eclipse.collections'))  : epl,
+
+            // https://checkerframework.org/manual/#license
+            // The more permissive MIT License applies to code that you might want
+            // to include in your own program, such as the annotations and run-time utility classes.
+            (group('org.checkerframework')): mit
+    ]
+}
+
+
+task checkLicenses {
+    description "Verify that all dependencies use white-listed licenses."
+    dependsOn ':downloadLicenses'
+
+    def bads = ""
+    doLast {
+        def xml = new XmlParser().parse('build/reports/license/license-dependency.xml')
+        xml.each { license ->
+            if (!acceptedLicenses.contains((license.@name).toLowerCase())) {
+                def depStrings = []
+                license.dependency.each { depStrings << it.text() }
+                bads = bads + depStrings + " =>  -${license.@name}- \n"
+            }
+        }
+        if (bads != "") {
+            throw new GradleException("Some 3rd parties are using licenses not in our accepted licenses list:\n" +
+                    bads +
+                    "Be careful, some 3rd parties may accept multiple licenses.\n" +
+                    "In this case, select the one you want to use by changing downloadLicenses.licenses\n"
+            )
+        }
+    }
+}
+check.dependsOn checkLicenses
+
+// disable license header check on source files
+license {
+    exclude "**/*"
+}


### PR DESCRIPTION
- checkLicenses task generates a "build/reports/license/license-dependency.html" file with the licenses report
- Added property to ignore all source files for license header scan