### PR TITLE
Add log4j bridge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
   // logger
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.10.0'
   compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.10.0'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.10.0'
 }
 
 jar {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="trace">
+    <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
Netty is using log4j v1.2. This is generating annoying warning messages. The best way to handle this is adding the bridge dependency between the two versions.