### PR TITLE
Adding test results to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,5 +46,13 @@ jobs:
 
       - run: ./gradlew build
 
-
-
+      - run:
+          name: Save test results
+          command: |
+             mkdir -p ~/junit/
+             find . -type f -regex ".*/build/test-results/test/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit


### PR DESCRIPTION
Adding our test results to CircleCI build data. This allow us to see a summary of the tests on CircleCI.

* https://circleci.com/docs/2.0/configuration-reference/#store_test_results
* https://circleci.com/docs/2.0/collect-test-data/#gradle-junit-results