### PR TITLE
Use application octet stream for the raw methods.

### DIFF
--- a/src/main/java/net/consensys/orion/api/cmd/OrionRoutes.java
+++ b/src/main/java/net/consensys/orion/api/cmd/OrionRoutes.java
@@ -76,9 +76,10 @@ public class OrionRoutes {
         .handler(new SendHandler(enclave, storage, networkNodes, serializer, JSON));
     router
         .post(SEND_RAW)
-        .produces(BINARY.httpHeaderValue)
-        .consumes(BINARY.httpHeaderValue)
-        .handler(new SendHandler(enclave, storage, networkNodes, serializer, BINARY));
+        .produces(APPLICATION_OCTET_STREAM.httpHeaderValue)
+        .consumes(APPLICATION_OCTET_STREAM.httpHeaderValue)
+        .handler(
+            new SendHandler(enclave, storage, networkNodes, serializer, APPLICATION_OCTET_STREAM));
 
     router
         .post(RECEIVE)
@@ -87,9 +88,9 @@ public class OrionRoutes {
         .handler(new ReceiveHandler(enclave, storage, serializer, JSON));
     router
         .post(RECEIVE_RAW)
-        .produces(BINARY.httpHeaderValue)
-        .consumes(BINARY.httpHeaderValue)
-        .handler(new ReceiveHandler(enclave, storage, serializer, BINARY));
+        .produces(APPLICATION_OCTET_STREAM.httpHeaderValue)
+        .consumes(APPLICATION_OCTET_STREAM.httpHeaderValue)
+        .handler(new ReceiveHandler(enclave, storage, serializer, APPLICATION_OCTET_STREAM));
 
     router.post(DELETE).handler(new DeleteHandler(storage));
 

--- a/src/main/java/net/consensys/orion/impl/http/server/HttpContentType.java
+++ b/src/main/java/net/consensys/orion/impl/http/server/HttpContentType.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 public enum HttpContentType {
   JSON(HttpHeaderValues.APPLICATION_JSON.toString()),
   BINARY(HttpHeaderValues.BINARY.toString()),
+  APPLICATION_OCTET_STREAM(HttpHeaderValues.APPLICATION_OCTET_STREAM.toString()),
   TEXT(HttpHeaderValues.TEXT_PLAIN.toString() + "; charset=utf-8"),
   HASKELL_ENCODED("application/haskell-stream"),
   CBOR("application/cbor");

--- a/src/test/java/net/consensys/orion/impl/http/handlers/ReceiveHandlerTest.java
+++ b/src/test/java/net/consensys/orion/impl/http/handlers/ReceiveHandlerTest.java
@@ -1,7 +1,7 @@
 package net.consensys.orion.impl.http.handlers;
 
 import static junit.framework.TestCase.assertTrue;
-import static net.consensys.orion.impl.http.server.HttpContentType.BINARY;
+import static net.consensys.orion.impl.http.server.HttpContentType.APPLICATION_OCTET_STREAM;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -81,13 +81,14 @@ public class ReceiveHandlerTest extends HandlerTest {
     // store it
     String key = storage.put(originalPayload);
     // Receive operation, sending a ReceivePayload request
-    RequestBody body = RequestBody.create(MediaType.parse(BINARY.httpHeaderValue), "");
+    RequestBody body =
+        RequestBody.create(MediaType.parse(APPLICATION_OCTET_STREAM.httpHeaderValue), "");
 
     Request request =
         new Request.Builder()
             .post(body)
-            .addHeader("Content-Type", BINARY.httpHeaderValue)
-            .addHeader("Accept", BINARY.httpHeaderValue)
+            .addHeader("Content-Type", APPLICATION_OCTET_STREAM.httpHeaderValue)
+            .addHeader("Accept", APPLICATION_OCTET_STREAM.httpHeaderValue)
             .addHeader("c11n-key", key)
             .url(baseUrl + "receiveraw")
             .build();
@@ -125,13 +126,14 @@ public class ReceiveHandlerTest extends HandlerTest {
         enclave.encrypt(toEncrypt, senderKey, new PublicKey[] {senderKey});
 
     String key = storage.put(originalPayload);
-    RequestBody body = RequestBody.create(MediaType.parse(BINARY.httpHeaderValue), "");
+    RequestBody body =
+        RequestBody.create(MediaType.parse(APPLICATION_OCTET_STREAM.httpHeaderValue), "");
 
     Request request =
         new Request.Builder()
             .post(body)
-            .addHeader("Content-Type", BINARY.httpHeaderValue)
-            .addHeader("Accept", BINARY.httpHeaderValue)
+            .addHeader("Content-Type", APPLICATION_OCTET_STREAM.httpHeaderValue)
+            .addHeader("Accept", APPLICATION_OCTET_STREAM.httpHeaderValue)
             .addHeader("c11n-key", key)
             .url(baseUrl + "receiveraw")
             .build();

--- a/src/test/java/net/consensys/orion/impl/http/handlers/SendHandlerTest.java
+++ b/src/test/java/net/consensys/orion/impl/http/handlers/SendHandlerTest.java
@@ -2,7 +2,7 @@ package net.consensys.orion.impl.http.handlers;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
-import static net.consensys.orion.impl.http.server.HttpContentType.BINARY;
+import static net.consensys.orion.impl.http.server.HttpContentType.APPLICATION_OCTET_STREAM;
 import static net.consensys.orion.impl.http.server.HttpContentType.CBOR;
 import static org.junit.Assert.assertArrayEquals;
 
@@ -208,7 +208,7 @@ public class SendHandlerTest extends HandlerTest {
 
     // build the binary sendRequest
     RequestBody body =
-        RequestBody.create(MediaType.parse(HttpContentType.BINARY.httpHeaderValue), toEncrypt);
+        RequestBody.create(MediaType.parse(APPLICATION_OCTET_STREAM.httpHeaderValue), toEncrypt);
     PublicKey sender = memoryKeyStore.generateKeyPair(keyConfig);
 
     String from = Base64.encode(sender.getEncoded());
@@ -225,8 +225,8 @@ public class SendHandlerTest extends HandlerTest {
             .url(baseUrl + "sendraw")
             .addHeader("c11n-from", from)
             .addHeader("c11n-to", String.join(",", to))
-            .addHeader("Content-Type", BINARY.httpHeaderValue)
-            .addHeader("Accept", BINARY.httpHeaderValue)
+            .addHeader("Content-Type", APPLICATION_OCTET_STREAM.httpHeaderValue)
+            .addHeader("Accept", APPLICATION_OCTET_STREAM.httpHeaderValue)
             .build();
 
     // execute request


### PR DESCRIPTION
Quorum uses application/octect-stream as the header for send/receieve raw, so updated Orion to match.