### PR TITLE
Do not rely on SendRequest class to serialize to JSON.

### DIFF
--- a/src/main/java/net/consensys/orion/impl/http/handler/send/SendRequest.java
+++ b/src/main/java/net/consensys/orion/impl/http/handler/send/SendRequest.java
@@ -17,17 +17,14 @@ public class SendRequest implements Serializable {
   private final String[] to; // b64 encoded
   private final byte[] rawPayload;
 
-  @JsonProperty("from")
   public Optional<String> from() {
     return Optional.ofNullable(from);
   }
 
-  @JsonProperty("to")
   public String[] to() {
     return to;
   }
 
-  @JsonProperty("payload")
   public String payload() {
     if (rawPayload == null) {
       return null;

--- a/src/performance-test/scala/net/consensys/orion/load/LoadSimulation.scala
+++ b/src/performance-test/scala/net/consensys/orion/load/LoadSimulation.scala
@@ -1,11 +1,11 @@
 package net.consensys.orion.load
 
 import java.util.Base64
+import collection.JavaConverters._
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure._
 import io.gatling.http.Predef._
-import net.consensys.orion.impl.http.handler.send.SendRequest
 import com.fasterxml.jackson.databind.ObjectMapper
 import scala.concurrent.duration._
 
@@ -29,7 +29,7 @@ class LoadSimulation extends Simulation {
   def buildSendRequests(host: String, from : String, to : Seq[String]): ChainBuilder = {
     return exec(http("sends")
     .post(s"$host/send")
-    .body(StringBody(mapper.writeValueAsString(new SendRequest(base64payload, from, to.toArray))))
+    .body(StringBody(mapper.writeValueAsString(Map("payload" -> base64payload, "from" -> from, "to" -> to.toArray).asJava)))
     .asJSON.check(jsonPath("$.key").saveAs("sendResponse")))
   }
 
@@ -55,6 +55,6 @@ class LoadSimulation extends Simulation {
     scenario("SendThenReceiveOneNode").exec(fooToFooRequests).exec(receiveFooRequests).inject(rampUsers(1000) over (2 minutes)),
     scenario("SendThenReceiveOtherNode").exec(fooToBarRequests).exec(receiveBarRequests).inject(rampUsers(1000) over (2 minutes)),
     scenario("SendThenReceiveTwoOtherNodes").exec(fooToBarAndFoobarRequests).exec(receiveBarRequests).
-      exec(receiveFooBarRequests).inject(atOnceUsers(10), rampUsers(100000) over (2 minutes))
+      exec(receiveFooBarRequests).inject(atOnceUsers(10), rampUsers(20000) over (2 minutes))
   )
 }

--- a/src/test/java/net/consensys/orion/impl/http/handlers/SendHandlerWithNodeKeysTest.java
+++ b/src/test/java/net/consensys/orion/impl/http/handlers/SendHandlerWithNodeKeysTest.java
@@ -12,11 +12,11 @@ import net.consensys.orion.impl.enclave.sodium.LibSodiumSettings;
 import net.consensys.orion.impl.enclave.sodium.SodiumEncryptedPayload;
 import net.consensys.orion.impl.enclave.sodium.SodiumPublicKey;
 import net.consensys.orion.impl.helpers.StubEnclave;
-import net.consensys.orion.impl.http.handler.send.SendRequest;
 import net.consensys.orion.impl.http.server.HttpContentType;
 import net.consensys.orion.impl.utils.Base64;
 
 import java.security.PublicKey;
+import java.util.Map;
 import java.util.Random;
 
 import com.muquit.libsodiumjna.SodiumKeyPair;
@@ -68,12 +68,9 @@ public class SendHandlerWithNodeKeysTest extends SendHandlerTest {
     FakePeer fakePeer = new FakePeer(new MockResponse().setBody(digest));
     networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
 
-    // configureRoutes our sendRequest
-    String payload = Base64.encode(toEncrypt);
-
     String[] to = new String[] {Base64.encode(fakePeer.publicKey.getEncoded())};
 
-    SendRequest sendRequest = new SendRequest(payload, null, to);
+    Map<String, Object> sendRequest = buildRequest(to, toEncrypt, null);
     Request request = buildPrivateAPIRequest("/send", HttpContentType.JSON, sendRequest);
 
     // execute request


### PR DESCRIPTION
Do not rely on SendRequest class to serialize to JSON. If you really have to build a SendRequest, use an utility method in tests instead.
Lower the performance test benchmark on performance tests so they can pass on a laptop.
