### PR TITLE
Disable classpath annotation processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ spotless {
 
 tasks.withType(JavaCompile) {
   options.compilerArgs += [
+    '-proc:none',
     '-Xlint:unchecked',
     '-Xlint:cast',
     '-Xlint:rawtypes',


### PR DESCRIPTION
Which will not be supported in Gradle 6.0 anyway