### PR TITLE
Set httpClient to null after it's closed so it cannot be closed twice

### DIFF
--- a/src/main/java/net/consensys/orion/impl/network/NetworkDiscovery.java
+++ b/src/main/java/net/consensys/orion/impl/network/NetworkDiscovery.java
@@ -47,7 +47,10 @@ public class NetworkDiscovery extends AbstractVerticle {
     for (Discoverer discoverer : discoverers.values()) {
       discoverer.cancel();
     }
-    httpClient.close();
+    if (httpClient != null) {
+      httpClient.close();
+      httpClient = null;
+    }
   }
 
   /**


### PR DESCRIPTION
We're getting stacktraces on stopping right now because NetworkDiscovery is attempted to close twice: one time as we close it explicitly, and one time through closing vertx, which attempts to close its verticles.