### PR TITLE
Adding Dockerfile and README instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:8-jdk
+
+RUN apt-get -qq update && \
+    apt-get -qq -y install libsodium-dev
+
+EXPOSE 8080
+EXPOSE 8888
+
+ADD build/distributions/orion*.tar.gz /tmp
+RUN mv /tmp/orion* /orion
+
+VOLUME /data
+
+CMD /orion/bin/orion /data/orion.conf

--- a/README.md
+++ b/README.md
@@ -138,3 +138,49 @@ database. It is not possible to recover a lost database without a backup.
 
 [This page](https://github.com/ConsenSys/orion/wiki/Disaster-Recovery-Strategies) contains more 
 information about disaster recovery strategies for Orion.
+
+## Docker
+
+There is a provided `Dockerfile` that can be used to build an image of Orion.
+
+To start the container, one needs to provide a volume with a set of keys and a configuration file.
+
+**Example:**
+
+**`orion.conf` configuration file:**
+```
+nodeurl = "http://127.0.0.1:8080/"
+nodeport = 8080
+clienturl = "http://127.0.0.1:8888/"
+clientport = 8888
+workdir = "/data"
+publickeys = ["orion.pub"]
+privatekeys = ["orion.key"]
+tls = "off"
+```
+
+**`data` folder:**
+```
+data
+  |--- orion.conf
+  |--- orion.pub
+  |--- orion.key
+```
+(you need to use orion to generate the keys)
+
+**Building the image:**
+``` 
+$ docker build --force-rm -t orion .
+``` 
+(make sure that you have built the project with `./gradlew build` before building the image)
+
+**Starting the container:**
+``` 
+$ docker run -d -p 8080:8080 -v data:/data orion
+``` 
+
+**To check that orion is up and running:**
+```
+$ curl -X GET http://localhost:8080/upcheck
+> I'm up!
+```

--- a/src/main/resources/default.conf
+++ b/src/main/resources/default.conf
@@ -3,3 +3,4 @@ nodeurl = "http://127.0.0.1:8080/"
 nodeport = 8080
 clienturl = "http://127.0.0.1:8888/"
 clientport = 8888
+tls = "off"


### PR DESCRIPTION
Adding Dockerfile and README instructions on how to run Orion in a docker container.