### PR TITLE
Revert enabling gzip

### DIFF
--- a/src/main/java/net/consensys/orion/api/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/api/cmd/Orion.java
@@ -340,10 +340,8 @@ public class Orion {
         vertx.createHttpServer(options).requestHandler(nodeRouter::accept).exceptionHandler(log::error).listen(
             completeFutureInHandler(nodeFuture));
     CompletableFuture<Boolean> clientFuture = new CompletableFuture<>();
-    HttpServerOptions clientOptions = new HttpServerOptions()
-        .setPort(config.clientPort())
-        .setHost(config.clientNetworkInterface())
-        .setCompressionSupported(true);
+    HttpServerOptions clientOptions =
+        new HttpServerOptions().setPort(config.clientPort()).setHost(config.clientNetworkInterface());
     clientHTTPServer =
         vertx.createHttpServer(clientOptions).requestHandler(clientRouter::accept).exceptionHandler(log::error).listen(
             completeFutureInHandler(clientFuture));


### PR DESCRIPTION
Revert "Enable gzip compression over the HTTP connection to the ethereum client"

This reverts commit cd0778c0170a81ef2ba3fb4d834cc6d691fecce1.