### PR TITLE
Skip license format check rather than ignoring errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ spotless {
   }
 }
 
+license { exclude "**/*" }
+
 
 //////
 // Compiler arguments
@@ -346,5 +348,3 @@ bintray {
     version { name = project.version }
   }
 }
-
-license { ignoreFailures true }


### PR DESCRIPTION
Replaces #159 