### PR TITLE
Fixing where we set LibSodium path

### DIFF
--- a/src/main/java/net/consensys/orion/api/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/api/cmd/Orion.java
@@ -256,10 +256,11 @@ public class Orion {
   }
 
   public void run(PrintStream out, PrintStream err, Config config) {
+    SodiumLibrary.setLibraryPath(config.libSodiumPath());
+
     SodiumFileKeyStore keyStore = new SodiumFileKeyStore(config);
     ConcurrentNetworkNodes networkNodes = new ConcurrentNetworkNodes(config, keyStore.nodeKeys());
 
-    SodiumLibrary.setLibraryPath(config.libSodiumPath());
     Enclave enclave = new LibSodiumEnclave(keyStore);
 
     Path workDir = config.workDir();


### PR DESCRIPTION
When reading the private key specified on the config file, we use LibSodium. For that reason, we need to set the library path before instantiating the `SodiumFileKeyStore`.