### PR TITLE
[PRIV-48] Use distinct keys to generate privacyGroupId.

### DIFF
--- a/src/main/java/net/consensys/orion/enclave/sodium/SodiumEnclave.java
+++ b/src/main/java/net/consensys/orion/enclave/sodium/SodiumEnclave.java
@@ -79,6 +79,7 @@ public class SodiumEnclave implements Enclave {
   public byte[] generatePrivacyGroupId(Box.PublicKey[] recipientsAndSender) {
     final List<byte[]> recipientsAndSenderList = Arrays
         .stream(recipientsAndSender)
+        .distinct()
         .sorted(Comparator.comparing(Box.PublicKey::hashCode))
         .map(Box.PublicKey::bytesArray)
         .collect(Collectors.toList());


### PR DESCRIPTION
If any public key is used multiple times is `privateFor` or `privateFrom`, we have to only use the unique keys to generate the `privacyGroupId` to avoid different privacy groups being generated. 