### PR TITLE
[OR-97] If empty, set `to` in SendRequest to the value `from`

### DIFF
--- a/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
@@ -78,6 +78,9 @@ public class SendHandler implements Handler<RoutingContext> {
     }
     log.debug(sendRequest);
 
+    if (sendRequest.to().length == 0) {
+      sendRequest.setTo(new String[] {sendRequest.from().orElse(null)});
+    }
     if (!sendRequest.isValid()) {
       throw new OrionException(OrionErrorCode.INVALID_PAYLOAD);
     }

--- a/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
@@ -27,7 +27,7 @@ import com.google.common.base.Strings;
 
 public class SendRequest implements Serializable {
   private final String from; // b64 encoded
-  private final String[] to; // b64 encoded
+  private String[] to; // b64 encoded
   private final byte[] rawPayload;
 
   public Optional<String> from() {
@@ -113,5 +113,9 @@ public class SendRequest implements Serializable {
 
   public byte[] rawPayload() {
     return rawPayload;
+  }
+
+  public void setTo(String[] to) {
+    this.to = to;
   }
 }


### PR DESCRIPTION
Orion returns a 404 if the `to` value in `SendRequest` is empty. Instead we can use `from` as the `to` value and not return an error. 