### PR TITLE
[OR-219] Enable send API to accept privacy group Id

### DIFF
--- a/src/acceptance-test/java/net/consensys/orion/acceptance/NodeUtils.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/NodeUtils.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.consensys.orion.cmd.Orion;
 import net.consensys.orion.config.Config;
+import net.consensys.orion.http.handler.receive.ReceiveResponse;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -116,8 +117,16 @@ public class NodeUtils {
     return viewer.receive(digest, viewerKey).orElseThrow(AssertionFailedError::new);
   }
 
+  public static ReceiveResponse viewTransactionPrivacyGroupId(EthClientStub viewer, String viewerKey, String digest) {
+    return viewer.receivePrivacy(digest, viewerKey);
+  }
+
   public static String sendTransaction(EthClientStub sender, String senderKey, String... recipientsKey) {
     return sender.send(originalPayload, senderKey, recipientsKey).orElseThrow(AssertionFailedError::new);
+  }
+
+  public static String sendTransactionPrivacyGroupId(EthClientStub sender, String senderKey, String privacyGroupId) {
+    return sender.send(originalPayload, senderKey, privacyGroupId).orElseThrow(AssertionFailedError::new);
   }
 
   /** Asserts the received payload matches that sent. */

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesSendReceiveUsingPrivacyGroupTest.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesSendReceiveUsingPrivacyGroupTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.acceptance.send.receive.privacyGroup;
+
+import static io.vertx.core.Vertx.vertx;
+import static net.consensys.cava.io.Base64.decodeBytes;
+import static net.consensys.cava.io.Base64.encodeBytes;
+import static net.consensys.cava.io.file.Files.copyResource;
+import static net.consensys.orion.acceptance.NodeUtils.assertTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.joinPathsAsTomlListEntry;
+import static net.consensys.orion.acceptance.NodeUtils.sendTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.sendTransactionPrivacyGroupId;
+import static net.consensys.orion.acceptance.NodeUtils.viewTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.viewTransactionPrivacyGroupId;
+import static net.consensys.orion.http.server.HttpContentType.CBOR;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.cava.junit.TempDirectory;
+import net.consensys.cava.junit.TempDirectoryExtension;
+import net.consensys.orion.acceptance.EthClientStub;
+import net.consensys.orion.acceptance.NodeUtils;
+import net.consensys.orion.cmd.Orion;
+import net.consensys.orion.config.Config;
+import net.consensys.orion.http.handler.receive.ReceiveResponse;
+import net.consensys.orion.http.server.HttpContentType;
+import net.consensys.orion.network.ConcurrentNetworkNodes;
+import net.consensys.orion.utils.Serializer;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Runs up a two nodes that communicates with each other. */
+@ExtendWith(TempDirectoryExtension.class)
+class DualNodesSendReceiveUsingPrivacyGroupTest {
+
+  private static final String PK_1_B_64 = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
+  private static final String PK_2_B_64 = "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=";
+
+  private Config firstNodeConfig;
+  private Config secondNodeConfig;
+  private ConcurrentNetworkNodes networkNodes;
+
+  private Orion firstOrionLauncher;
+  private Orion secondOrionLauncher;
+  private Vertx vertx;
+  private HttpClient firstHttpClient;
+  private HttpClient secondHttpClient;
+
+  @BeforeEach
+  void setUpDualNodes(@TempDirectory Path tempDir) throws Exception {
+
+    Path key1pub = copyResource("key1.pub", tempDir.resolve("key1.pub"));
+    Path key1key = copyResource("key1.key", tempDir.resolve("key1.key"));
+    Path key2pub = copyResource("key2.pub", tempDir.resolve("key2.pub"));
+    Path key2key = copyResource("key2.key", tempDir.resolve("key2.key"));
+
+    String jdbcUrl = "jdbc:h2:" + tempDir.resolve("node2").toString();
+    try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+      Statement st = conn.createStatement();
+      st.executeUpdate("create table if not exists store(key binary, value binary, primary key(key))");
+    }
+
+    firstNodeConfig = NodeUtils.nodeConfig(
+        tempDir,
+        0,
+        "127.0.0.1",
+        0,
+        "127.0.0.1",
+        "node1",
+        joinPathsAsTomlListEntry(key1pub),
+        joinPathsAsTomlListEntry(key1key),
+        "off",
+        "tofu",
+        "tofu",
+        "leveldb:database/node1");
+    secondNodeConfig = NodeUtils.nodeConfig(
+        tempDir,
+        0,
+        "127.0.0.1",
+        0,
+        "127.0.0.1",
+        "node2",
+        joinPathsAsTomlListEntry(key2pub),
+        joinPathsAsTomlListEntry(key2key),
+        "off",
+        "tofu",
+        "tofu",
+        "sql:" + jdbcUrl);
+    vertx = vertx();
+    firstOrionLauncher = NodeUtils.startOrion(firstNodeConfig);
+    firstHttpClient = vertx.createHttpClient();
+    secondOrionLauncher = NodeUtils.startOrion(secondNodeConfig);
+    secondHttpClient = vertx.createHttpClient();
+    Box.PublicKey pk1 = Box.PublicKey.fromBytes(decodeBytes(PK_1_B_64));
+    Box.PublicKey pk2 = Box.PublicKey.fromBytes(decodeBytes(PK_2_B_64));
+    networkNodes = new ConcurrentNetworkNodes(NodeUtils.url("127.0.0.1", firstOrionLauncher.nodePort()));
+
+    networkNodes.addNode(pk1, NodeUtils.url("127.0.0.1", firstOrionLauncher.nodePort()));
+    networkNodes.addNode(pk2, NodeUtils.url("127.0.0.1", secondOrionLauncher.nodePort()));
+    // prepare /partyinfo payload (our known peers)
+    RequestBody partyInfoBody =
+        RequestBody.create(MediaType.parse(CBOR.httpHeaderValue), Serializer.serialize(CBOR, networkNodes));
+    // call http endpoint
+    OkHttpClient httpClient = new OkHttpClient();
+
+    final String firstNodeBaseUrl = NodeUtils.urlString("127.0.0.1", firstOrionLauncher.nodePort());
+    Request request = new Request.Builder().post(partyInfoBody).url(firstNodeBaseUrl + "/partyinfo").build();
+    // first /partyinfo call may just get the one node, so wait until we get at least 2 nodes
+    await().atMost(5, TimeUnit.SECONDS).until(() -> getPartyInfoResponse(httpClient, request).nodeURLs().size() == 2);
+
+  }
+
+  private ConcurrentNetworkNodes getPartyInfoResponse(OkHttpClient httpClient, Request request) throws Exception {
+    Response resp = httpClient.newCall(request).execute();
+    assertEquals(200, resp.code());
+
+    ConcurrentNetworkNodes partyInfoResponse =
+        Serializer.deserialize(HttpContentType.CBOR, ConcurrentNetworkNodes.class, resp.body().bytes());
+    return partyInfoResponse;
+  }
+
+  @AfterEach
+  void tearDown() {
+    firstOrionLauncher.stop();
+    secondOrionLauncher.stop();
+    vertx.close();
+  }
+
+  @Test
+  void receiverCanViewWhenSentToPrivacyGroup() {
+    final EthClientStub firstNode = NodeUtils.client(firstOrionLauncher.clientPort(), firstHttpClient);
+    final EthClientStub secondNode = NodeUtils.client(secondOrionLauncher.clientPort(), secondHttpClient);
+
+    final String digest = sendTransaction(firstNode, PK_1_B_64, PK_2_B_64);
+    final ReceiveResponse receivedPayload = viewTransactionPrivacyGroupId(firstNode, PK_1_B_64, digest);
+
+    assertTransaction(receivedPayload.getPayload());
+
+    final String digestPrivacyGroup =
+        sendTransactionPrivacyGroupId(firstNode, PK_1_B_64, encodeBytes(receivedPayload.getPrivacyGroupId()));
+    final byte[] response = viewTransaction(secondNode, PK_2_B_64, digestPrivacyGroup);
+
+    assertTransaction(response);
+  }
+
+  @Test
+  void senderCanViewWhenSentToPrivacyGroup() {
+    final EthClientStub firstNode = NodeUtils.client(firstOrionLauncher.clientPort(), firstHttpClient);
+
+    final String digest = sendTransaction(firstNode, PK_1_B_64, PK_2_B_64);
+    final ReceiveResponse receivedPayload = viewTransactionPrivacyGroupId(firstNode, PK_1_B_64, digest);
+
+    assertTransaction(receivedPayload.getPayload());
+
+    final String digestPriv =
+        sendTransactionPrivacyGroupId(firstNode, PK_1_B_64, encodeBytes(receivedPayload.getPrivacyGroupId()));
+    final byte[] response = viewTransaction(firstNode, PK_1_B_64, digestPriv);
+
+    assertTransaction(response);
+
+  }
+}

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -30,6 +30,7 @@ import net.consensys.orion.config.Config;
 import net.consensys.orion.config.ConfigException;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.EncryptedPayload;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 import net.consensys.orion.enclave.sodium.FileKeyStore;
 import net.consensys.orion.enclave.sodium.SodiumEnclave;
 import net.consensys.orion.http.handler.partyinfo.PartyInfoHandler;
@@ -118,7 +119,7 @@ public class Orion {
       ConcurrentNetworkNodes networkNodes,
       Enclave enclave,
       Storage<EncryptedPayload> storage,
-      Storage<String[]> privacyGroupStorage,
+      Storage<PrivacyGroupPayload> privacyGroupStorage,
       Router nodeRouter,
       Router clientRouter,
       Config config) {

--- a/src/main/java/net/consensys/orion/enclave/PrivacyGroupPayload.java
+++ b/src/main/java/net/consensys/orion/enclave/PrivacyGroupPayload.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.enclave;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PrivacyGroupPayload implements Serializable {
+
+  private final String[] addresses;
+  private final State state;
+  private final Type type;
+  private final byte[] randomSeed;
+
+  @JsonCreator
+  public PrivacyGroupPayload(
+      @JsonProperty("addresses") String[] addresses,
+      @JsonProperty("state") State state,
+      @JsonProperty("type") Type type,
+      @JsonProperty("randomSeed") byte[] randomSeed) {
+    this.addresses = addresses;
+    this.state = state;
+    this.type = type;
+    this.randomSeed = randomSeed;
+  }
+
+  @JsonProperty("addresses")
+  public String[] addresses() {
+    return addresses;
+  }
+
+  @JsonProperty("state")
+  public State state() {
+    return state;
+  }
+
+  @JsonProperty("type")
+  public Type type() {
+    return type;
+  }
+
+  @JsonProperty("randomSeed")
+  public byte[] randomSeed() {
+    return randomSeed;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PrivacyGroupPayload that = (PrivacyGroupPayload) o;
+    return Arrays.equals(addresses, that.addresses)
+        && Objects.equals(state, that.state)
+        && Objects.equals(type, that.type)
+        && Arrays.equals(randomSeed, that.randomSeed);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(addresses);
+    result = 31 * result + state.hashCode();
+    result = 31 * result + type.hashCode();
+    result = 31 * result + Arrays.hashCode(randomSeed);
+    return result;
+  }
+
+  public enum State {
+    ACTIVE, DELETED
+  }
+  public enum Type {
+    QUORUM, PANTHEON
+  }
+}

--- a/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
+++ b/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
@@ -45,7 +45,10 @@ public enum OrionErrorCode {
   ENCLAVE_NOT_PAYLOAD_OWNER("EnclaveNotPayloadOwner"),
   ENCLAVE_UNSUPPORTED_PRIVATE_KEY_TYPE("EnclaveUnsupportedPrivateKeyType"),
   ENCLAVE_STORAGE_DECRYPT("EnclaveStorageDecrypt"),
-  ENCLAVE_PRIVACY_GROUP_CREATION("EnclavePrivacyGroupIdCreation");
+  ENCLAVE_PRIVACY_GROUP_CREATION("EnclavePrivacyGroupIdCreation"),
+
+  /** Storing privacy group issue */
+  ENCLAVE_UNABLE_STORE_PRIVACY_GROUP("PrivacyGroupNotStored");
 
   private final String code;
 

--- a/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
+++ b/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
@@ -48,7 +48,8 @@ public enum OrionErrorCode {
   ENCLAVE_PRIVACY_GROUP_CREATION("EnclavePrivacyGroupIdCreation"),
 
   /** Storing privacy group issue */
-  ENCLAVE_UNABLE_STORE_PRIVACY_GROUP("PrivacyGroupNotStored");
+  ENCLAVE_UNABLE_STORE_PRIVACY_GROUP("PrivacyGroupNotStored"),
+  ENCLAVE_PRIVACY_GROUP_MISSING("PrivacyGroupNotFound");
 
   private final String code;
 

--- a/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
@@ -82,7 +82,7 @@ public class SendHandler implements Handler<RoutingContext> {
     }
     log.debug(sendRequest);
 
-    if (sendRequest.to().length == 0) {
+    if (sendRequest.to() == null && !sendRequest.privacyGroupId().isPresent()) {
       sendRequest.setTo(new String[] {sendRequest.from().orElse(null)});
     }
     if (!sendRequest.isValid()) {

--- a/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
@@ -111,6 +111,7 @@ public class SendHandler implements Handler<RoutingContext> {
     } else if (sendRequest.privacyGroupId().isPresent()) {
       privacyGroupStorage.get(sendRequest.privacyGroupId().get()).thenApply((result) -> {
         List<Box.PublicKey> toKeys = Arrays.stream(result.get()).map(enclave::readKey).collect(Collectors.toList());
+        toKeys.remove(fromKey);
         send(routingContext, sendRequest, fromKey, toKeys);
         return result;
       });

--- a/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
@@ -179,19 +179,16 @@ public class SendHandler implements Handler<RoutingContext> {
         handleFailure(routingContext, ex);
         return;
       }
-      storage
-          .put(encryptedPayload)
-          .thenAccept((result) -> privacyGroupStorage.put(sendRequest.to()).thenAccept((privacyResult) -> {
+      storage.put(encryptedPayload).thenAccept((result) -> {
 
-            final Buffer responseData;
-            if (contentType == JSON) {
-              responseData = Buffer.buffer(Serializer.serialize(JSON, Collections.singletonMap("key", digest)));
-            } else {
-              responseData = Buffer.buffer(digest);
-            }
-            routingContext.response().end(responseData);
-          }).exceptionally(privacyEx -> handleFailure(routingContext, privacyEx)))
-          .exceptionally(e -> handleFailure(routingContext, e));
+        final Buffer responseData;
+        if (contentType == JSON) {
+          responseData = Buffer.buffer(Serializer.serialize(JSON, Collections.singletonMap("key", digest)));
+        } else {
+          responseData = Buffer.buffer(digest);
+        }
+        routingContext.response().end(responseData);
+      }).exceptionally(e -> handleFailure(routingContext, e));
     });
   }
 

--- a/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
@@ -20,10 +20,10 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.google.common.base.Strings;
 
 public class SendRequest implements Serializable {
@@ -60,11 +60,9 @@ public class SendRequest implements Serializable {
     this(decodePayload(payload), from, to);
   }
 
-  @JsonAnySetter
-  void setDetail(String key, String value) {
-    if (key.equals("privacyGroupId")) {
-      privacyGroupId = value;
-    }
+  @JsonSetter("privacyGroupId")
+  void setPrivacyGroupId(String privacyGroupId) {
+    this.privacyGroupId = privacyGroupId;
   }
 
   private static byte[] decodePayload(String payload) {

--- a/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,6 +30,12 @@ public class SendRequest implements Serializable {
   private final String from; // b64 encoded
   private String[] to; // b64 encoded
   private final byte[] rawPayload;
+  private String privacyGroupId = null;
+
+  public Optional<String> privacyGroupId() {
+    return Optional.ofNullable(privacyGroupId);
+  }
+
 
   public Optional<String> from() {
     return Optional.ofNullable(from);
@@ -53,6 +60,13 @@ public class SendRequest implements Serializable {
     this(decodePayload(payload), from, to);
   }
 
+  @JsonAnySetter
+  void setDetail(String key, String value) {
+    if (key.equals("privacyGroupId")) {
+      privacyGroupId = value;
+    }
+  }
+
   private static byte[] decodePayload(String payload) {
     if (payload == null) {
       return new byte[0];
@@ -72,9 +86,8 @@ public class SendRequest implements Serializable {
 
   @JsonIgnore
   public boolean isValid() {
-    return to != null
-        && to.length > 0
-        && Arrays.stream(to).noneMatch(Strings::isNullOrEmpty)
+    return ((to != null && to.length > 0 && Arrays.stream(to).noneMatch(Strings::isNullOrEmpty))
+        || privacyGroupId != null)
         && rawPayload != null
         && rawPayload.length > 0
         && (from == null || from.length() > 0);

--- a/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
+++ b/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.storage;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.consensys.cava.io.Base64.encodeBytes;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.concurrent.AsyncResult;
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.cava.kv.KeyValueStore;
+import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.http.server.HttpContentType;
+import net.consensys.orion.utils.Serializer;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+
+public class PrivacyGroupStorage implements Storage<String[]> {
+
+  private final KeyValueStore store;
+  private final Enclave enclave;
+
+  public PrivacyGroupStorage(KeyValueStore store, Enclave enclave) {
+    this.store = store;
+    this.enclave = enclave;
+  }
+
+  @Override
+  public AsyncResult<String> put(String[] data) {
+    String key = generateDigest(data);
+    Bytes keyBytes = Bytes.wrap(key.getBytes(UTF_8));
+    Bytes dataBytes = Bytes.wrap(Serializer.serialize(HttpContentType.CBOR, data));
+    return store.putAsync(keyBytes, dataBytes).thenSupply(() -> key);
+  }
+
+  @Override
+  public String generateDigest(String[] data) {
+    Box.PublicKey[] addresses = Arrays.stream(data).map(enclave::readKey).toArray(Box.PublicKey[]::new);
+    return encodeBytes(enclave.generatePrivacyGroupId(addresses));
+  }
+
+
+  @Override
+  public AsyncResult<Optional<String[]>> get(String key) {
+    Bytes keyBytes = Bytes.wrap(key.getBytes(UTF_8));
+    return store.getAsync(keyBytes).thenApply(
+        maybeBytes -> Optional.ofNullable(maybeBytes).map(
+            bytes -> Serializer.deserialize(HttpContentType.CBOR, String[].class, bytes.toArrayUnsafe())));
+  }
+}

--- a/src/test/java/net/consensys/orion/helpers/StubEnclave.java
+++ b/src/test/java/net/consensys/orion/helpers/StubEnclave.java
@@ -19,9 +19,12 @@ import net.consensys.orion.enclave.EncryptedPayload;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /*
  * A very simple test class that implements the enclave interface and does minimal encryption operations that do not do
@@ -75,9 +78,11 @@ public class StubEnclave implements Enclave {
 
     EncryptedKey[] encryptedKeys;
     Map<Box.PublicKey, Integer> encryptedKeyOwners = new HashMap<>();
+    ArrayList<Box.PublicKey> keys = new ArrayList<>();
 
     if (recipients != null && recipients.length > 0) {
       encryptedKeys = new EncryptedKey[recipients.length];
+      keys = new ArrayList<>(Arrays.stream(recipients).collect(Collectors.toList()));
       for (int i = 0; i < recipients.length; i++) {
         encryptedKeyOwners.put(recipients[i], i);
         encryptedKeys[i] = new EncryptedKey(recipients[i].bytesArray());
@@ -85,13 +90,17 @@ public class StubEnclave implements Enclave {
     } else {
       encryptedKeys = new EncryptedKey[0];
     }
+
+    if (senderKey != null) {
+      keys.add(senderKey);
+    }
     return new EncryptedPayload(
         senderKey,
         nonce,
         encryptedKeys,
         ciphterText,
         encryptedKeyOwners,
-        generatePrivacyGroupId(recipients));
+        generatePrivacyGroupId(keys.toArray(new Box.PublicKey[0])));
   }
 
   @Override

--- a/src/test/java/net/consensys/orion/http/handler/HandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/HandlerTest.java
@@ -29,6 +29,7 @@ import net.consensys.orion.helpers.StubEnclave;
 import net.consensys.orion.http.server.HttpContentType;
 import net.consensys.orion.network.ConcurrentNetworkNodes;
 import net.consensys.orion.storage.EncryptedPayloadStorage;
+import net.consensys.orion.storage.PrivacyGroupStorage;
 import net.consensys.orion.storage.Sha512_256StorageKeyBuilder;
 import net.consensys.orion.storage.Storage;
 import net.consensys.orion.storage.StorageKeyBuilder;
@@ -73,6 +74,7 @@ abstract class HandlerTest {
 
   private KeyValueStore storage;
   protected Storage<EncryptedPayload> payloadStorage;
+  protected Storage<String[]> privacyGroupStorage;
 
   @BeforeEach
   void setUp(@TempDirectory Path tempDir) throws Exception {
@@ -95,9 +97,18 @@ abstract class HandlerTest {
     vertx = Vertx.vertx();
     StorageKeyBuilder keyBuilder = new Sha512_256StorageKeyBuilder();
     payloadStorage = new EncryptedPayloadStorage(storage, keyBuilder);
+    privacyGroupStorage = new PrivacyGroupStorage(storage, enclave);
     Router publicRouter = Router.router(vertx);
     Router privateRouter = Router.router(vertx);
-    Orion.configureRoutes(vertx, networkNodes, enclave, payloadStorage, publicRouter, privateRouter, config);
+    Orion.configureRoutes(
+        vertx,
+        networkNodes,
+        enclave,
+        payloadStorage,
+        privacyGroupStorage,
+        publicRouter,
+        privateRouter,
+        config);
 
     setupNodeServer(publicRouter);
     setupClientServer(privateRouter);

--- a/src/test/java/net/consensys/orion/http/handler/HandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/HandlerTest.java
@@ -24,6 +24,7 @@ import net.consensys.orion.cmd.Orion;
 import net.consensys.orion.config.Config;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.EncryptedPayload;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 import net.consensys.orion.exception.OrionErrorCode;
 import net.consensys.orion.helpers.StubEnclave;
 import net.consensys.orion.http.server.HttpContentType;
@@ -74,7 +75,7 @@ abstract class HandlerTest {
 
   private KeyValueStore storage;
   protected Storage<EncryptedPayload> payloadStorage;
-  protected Storage<String[]> privacyGroupStorage;
+  protected Storage<PrivacyGroupPayload> privacyGroupStorage;
 
   @BeforeEach
   void setUp(@TempDirectory Path tempDir) throws Exception {


### PR DESCRIPTION
Send API can be invoked in 2 ways, with the following arguments -

1. `from`, `to` and `payload`
2. `from`, `privacyGroupId` and `payload`. 

Both invocations return `key`. 

When /send is called with `from` and `to`, the privacy group Id is stored.  It is also stored when we call /privacyGroupId. 

Assumptions: 

- The privacy group Id is already in the storage before invoking send with the privacy group. 