### PR TITLE
 [OR-226] Propagate the delete privacy group changes to all peers

### DIFF
--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -187,7 +187,7 @@ public class Orion {
         new PrivacyGroupHandler(privacyGroupStorage, networkNodes, enclave, vertx, config));
 
     clientRouter.post("/deletePrivacyGroupId").consumes(JSON.httpHeaderValue).produces(JSON.httpHeaderValue).handler(
-        new DeletePrivacyGroupHandler(privacyGroupStorage));
+        new DeletePrivacyGroupHandler(privacyGroupStorage, networkNodes, enclave, vertx, config));
   }
 
   public Orion() {

--- a/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
+++ b/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
@@ -50,6 +50,7 @@ public enum OrionErrorCode {
   /** Storing privacy group issue */
   ENCLAVE_UNABLE_STORE_PRIVACY_GROUP("PrivacyGroupNotStored"),
   ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP("PrivacyGroupNotDeleted"),
+  ENCLAVE_UNABLE_PUSH_DELETE_PRIVACY_GROUP("PrivacyGroupNotPushed"),
   ENCLAVE_PRIVACY_GROUP_MISSING("PrivacyGroupNotFound");
 
   private final String code;

--- a/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupHandler.java
@@ -14,25 +14,54 @@ package net.consensys.orion.http.handler.privacy;
 
 import static net.consensys.orion.http.server.HttpContentType.JSON;
 
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.orion.config.Config;
+import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.PrivacyGroupPayload;
 import net.consensys.orion.exception.OrionErrorCode;
 import net.consensys.orion.exception.OrionException;
+import net.consensys.orion.http.server.HttpContentType;
+import net.consensys.orion.network.ConcurrentNetworkNodes;
+import net.consensys.orion.network.NodeHttpClientBuilder;
 import net.consensys.orion.storage.Storage;
 import net.consensys.orion.utils.Serializer;
 
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Delete the privacy group given the privacyGroupId.
  */
 public class DeletePrivacyGroupHandler implements Handler<RoutingContext> {
 
-  private final Storage<PrivacyGroupPayload> privacyGroupStorage;
+  private static final Logger log = LogManager.getLogger();
 
-  public DeletePrivacyGroupHandler(Storage<PrivacyGroupPayload> privacyGroupStorage) {
+  private final Storage<PrivacyGroupPayload> privacyGroupStorage;
+  private final ConcurrentNetworkNodes networkNodes;
+  private final Enclave enclave;
+  private final HttpClient httpClient;
+
+  public DeletePrivacyGroupHandler(
+      Storage<PrivacyGroupPayload> privacyGroupStorage,
+      ConcurrentNetworkNodes networkNodes,
+      Enclave enclave,
+      Vertx vertx,
+      Config config) {
     this.privacyGroupStorage = privacyGroupStorage;
+    this.networkNodes = networkNodes;
+    this.enclave = enclave;
+    this.httpClient = NodeHttpClientBuilder.build(vertx, config, 1500);
   }
 
   @Override
@@ -41,22 +70,83 @@ public class DeletePrivacyGroupHandler implements Handler<RoutingContext> {
     byte[] request = routingContext.getBody().getBytes();
     DeletePrivacyGroupRequest privacyGroup = Serializer.deserialize(JSON, DeletePrivacyGroupRequest.class, request);
 
-    privacyGroupStorage.get(privacyGroup.privacyGroupId()).thenAccept((res) -> {
-      if (res.isPresent() && res.get().state() == PrivacyGroupPayload.State.DELETED) {
+    privacyGroupStorage.get(privacyGroup.privacyGroupId()).thenAccept((result) -> {
+      if (!result.isPresent() || result.get().state() == PrivacyGroupPayload.State.DELETED) {
         routingContext
-            .fail(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP, "group already deleted"));
+            .fail(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP, "couldn't delete group"));
       } else {
-        privacyGroupStorage.delete(privacyGroup.privacyGroupId()).thenAccept((result) -> {
-          if (result.isPresent() && result.get().state() == PrivacyGroupPayload.State.DELETED) {
-            Buffer toReturn = Buffer.buffer(Serializer.serialize(JSON, result.get().state()));
-            routingContext.response().end(toReturn);
-          } else {
-            routingContext
-                .fail(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP, "couldn't delete group"));
+        PrivacyGroupPayload privacyGroupPayload = result.get();
+
+        // set state to deleted and propagate and store it
+        privacyGroupPayload.setState(PrivacyGroupPayload.State.DELETED);
+
+        List<Box.PublicKey> addressListToForward = Arrays
+            .stream(privacyGroupPayload.addresses())
+            .filter(key -> !key.equals(privacyGroup.from())) // don't forward to self
+            .distinct()
+            .map(enclave::readKey)
+            .collect(Collectors.toList());
+
+        if (addressListToForward.stream().anyMatch(pKey -> networkNodes.urlForRecipient(pKey) == null)) {
+          routingContext.fail(new OrionException(OrionErrorCode.NODE_MISSING_PEER_URL, "couldn't find peer URL "));
+          return;
+        }
+        // propagate payload
+        log.debug("propagating payload");
+
+        @SuppressWarnings("rawtypes")
+        CompletableFuture[] cfs = addressListToForward.stream().map(pKey -> {
+          URL recipientURL = networkNodes.urlForRecipient(pKey);
+
+          CompletableFuture<Boolean> responseFuture = new CompletableFuture<>();
+
+          // serialize payload, stripping non-relevant encryptedKeys, and configureRoutes payload
+          final byte[] payload = Serializer.serialize(HttpContentType.CBOR, privacyGroupPayload);
+
+          // execute request
+          httpClient
+              .post(recipientURL.getPort(), recipientURL.getHost(), "/pushPrivacyGroup")
+              .putHeader("Content-Type", "application/cbor")
+              .handler(response -> response.bodyHandler(responseBody -> {
+                if (response.statusCode() != 200 || !privacyGroup.privacyGroupId().equals(responseBody.toString())) {
+                  responseFuture
+                      .completeExceptionally(new OrionException(OrionErrorCode.NODE_PROPAGATING_TO_ALL_PEERS));
+                } else {
+                  responseFuture.complete(true);
+                }
+              }))
+              .exceptionHandler(
+                  ex -> responseFuture
+                      .completeExceptionally(new OrionException(OrionErrorCode.NODE_PUSHING_TO_PEER, ex)))
+              .end(Buffer.buffer(payload));
+
+          return responseFuture;
+        }).toArray(CompletableFuture[]::new);
+
+        CompletableFuture.allOf(cfs).whenComplete((all, ex) -> {
+          if (ex != null) {
+            handleFailure(routingContext, ex);
+            return;
           }
-        }).exceptionally(
-            e -> routingContext.fail(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP, e)));
+
+          privacyGroupStorage.put(privacyGroupPayload).thenAccept((digest) -> {
+            Buffer toReturn = Buffer.buffer(Serializer.serialize(JSON, digest));
+            routingContext.response().end(toReturn);
+          }).exceptionally(
+              e -> routingContext.fail(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_STORE_PRIVACY_GROUP, e)));
+        });
       }
     });
+  }
+
+  private void handleFailure(RoutingContext routingContext, Throwable ex) {
+    log.warn("propagating the payload failed");
+
+    Throwable cause = ex.getCause();
+    if (cause instanceof OrionException) {
+      routingContext.fail(cause);
+    } else {
+      routingContext.fail(new OrionException(OrionErrorCode.NODE_PROPAGATING_TO_ALL_PEERS, ex));
+    }
   }
 }

--- a/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupRequest.java
@@ -20,14 +20,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class DeletePrivacyGroupRequest implements Serializable {
 
   private final String privacyGroupId;
+  private final String from;
 
   @JsonCreator
-  public DeletePrivacyGroupRequest(@JsonProperty("privacyGroupId") String privacyGroupId) {
+  public DeletePrivacyGroupRequest(
+      @JsonProperty("privacyGroupId") String privacyGroupId,
+      @JsonProperty("from") String from) {
     this.privacyGroupId = privacyGroupId;
+    this.from = from;
   }
 
   @JsonProperty("privacyGroupId")
   public String privacyGroupId() {
     return privacyGroupId;
+  }
+
+  @JsonProperty("from")
+  public String from() {
+    return from;
   }
 }

--- a/src/main/java/net/consensys/orion/storage/EncryptedPayloadStorage.java
+++ b/src/main/java/net/consensys/orion/storage/EncryptedPayloadStorage.java
@@ -35,12 +35,6 @@ public class EncryptedPayloadStorage implements Storage<EncryptedPayload> {
   }
 
   @Override
-  public AsyncResult<Optional<EncryptedPayload>> delete(String key) {
-    // throw error if this is called, as we shouldn't delete encrypted payload.
-    return get("").thenApply((res) -> res);
-  }
-
-  @Override
   public AsyncResult<String> put(EncryptedPayload data) {
     String key = generateDigest(data);
     Bytes keyBytes = Bytes.wrap(key.getBytes(UTF_8));

--- a/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
+++ b/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
@@ -39,19 +39,6 @@ public class PrivacyGroupStorage implements Storage<PrivacyGroupPayload> {
   }
 
   @Override
-  public AsyncResult<Optional<PrivacyGroupPayload>> delete(String key) {
-    return get(key).thenApply((result) -> {
-      PrivacyGroupPayload privacyGroupPayload = null;
-      if (result.isPresent()) {
-        privacyGroupPayload = result.get();
-        privacyGroupPayload.setState(PrivacyGroupPayload.State.DELETED);
-        put(privacyGroupPayload);
-      }
-      return Optional.ofNullable(privacyGroupPayload);
-    });
-  }
-
-  @Override
   public AsyncResult<String> put(PrivacyGroupPayload data) {
     String key = generateDigest(data);
     Bytes keyBytes = Bytes.wrap(key.getBytes(UTF_8));

--- a/src/main/java/net/consensys/orion/storage/Storage.java
+++ b/src/main/java/net/consensys/orion/storage/Storage.java
@@ -19,14 +19,6 @@ import java.util.Optional;
 public interface Storage<T> {
 
   /**
-   * Deletes data in the store.
-   *
-   * @param key should be base64 encoded UTF-8 string
-   * @return The retrieved data.
-   */
-  AsyncResult<Optional<T>> delete(String key);
-
-  /**
    * Stores data in the store.
    *
    * @param data The data to store.

--- a/src/test/java/net/consensys/orion/helpers/FakePeer.java
+++ b/src/test/java/net/consensys/orion/helpers/FakePeer.java
@@ -13,6 +13,7 @@
 package net.consensys.orion.helpers;
 
 import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.orion.enclave.sodium.MemoryKeyStore;
 
 import java.io.IOException;
 import java.net.URL;
@@ -24,11 +25,22 @@ public class FakePeer {
   public final MockWebServer server;
   public final Box.PublicKey publicKey;
 
+  public FakePeer(MockResponse response, MemoryKeyStore memoryKeyStore) throws IOException {
+    server = new MockWebServer();
+    publicKey = memoryKeyStore.generateKeyPair();
+    server.enqueue(response);
+    server.start();
+  }
+
   public FakePeer(MockResponse response, Box.PublicKey publicKey) throws IOException {
     server = new MockWebServer();
     this.publicKey = publicKey;
     server.enqueue(response);
     server.start();
+  }
+
+  public void addResponse(MockResponse response) {
+    server.enqueue(response);
   }
 
   public URL getURL() {


### PR DESCRIPTION
Once a privacy group is deleted, the change should be sent to all members of the group to delete the same. 