### PR TITLE
Keep the generation of privacy group consistent.

### DIFF
--- a/src/main/java/net/consensys/orion/enclave/Enclave.java
+++ b/src/main/java/net/consensys/orion/enclave/Enclave.java
@@ -23,9 +23,10 @@ public interface Enclave {
    * @param plaintext Plaintext to encrypt
    * @param senderKey public key of the sender of the message.
    * @param recipients public keys of the recipients.
+   * @param seed random seed to generate privacy group Id
    * @return Returns a EncryptedPayload that encapsulates the ciphertext and related metadata.
    */
-  EncryptedPayload encrypt(byte[] plaintext, Box.PublicKey senderKey, Box.PublicKey[] recipients);
+  EncryptedPayload encrypt(byte[] plaintext, Box.PublicKey senderKey, Box.PublicKey[] recipients, byte[] seed);
 
   /**
    * Decrypt the cipher text in the encrypted payload, using the private key associated with the public key identity. It
@@ -44,5 +45,5 @@ public interface Enclave {
 
   Box.PublicKey readKey(String b64);
 
-  byte[] generatePrivacyGroupId(Box.PublicKey[] recipientsAndSender);
+  byte[] generatePrivacyGroupId(Box.PublicKey[] recipientsAndSender, byte[] seed, PrivacyGroupPayload.Type type);
 }

--- a/src/main/java/net/consensys/orion/enclave/sodium/SodiumEnclave.java
+++ b/src/main/java/net/consensys/orion/enclave/sodium/SodiumEnclave.java
@@ -65,12 +65,7 @@ public class SodiumEnclave implements Enclave {
     final EncryptedKey[] encryptedKeys =
         encryptPayloadKeyForRecipients(payloadKey, recipientsAndSender, senderSecretKey, nonce);
 
-    final byte[] privacyGroupId;
-    if (seed == null) {
-      privacyGroupId = generatePrivacyGroupId(recipientsAndSender, null, PrivacyGroupPayload.Type.LEGACY);
-    } else {
-      privacyGroupId = generatePrivacyGroupId(recipientsAndSender, seed, PrivacyGroupPayload.Type.PANTHEON);
-    }
+    final byte[] privacyGroupId = generatePrivacyGroupId(recipientsAndSender, seed, PrivacyGroupPayload.Type.PANTHEON);
 
     return new EncryptedPayload(
         senderKey,
@@ -98,7 +93,7 @@ public class SodiumEnclave implements Enclave {
     byte[] groupId = Hash.keccak256(rlpEncoded).toArray();
 
     // concatenate the PrivacyGroupId with a random seed
-    if (type.equals(PrivacyGroupPayload.Type.PANTHEON)) {
+    if (seed != null && type.equals(PrivacyGroupPayload.Type.PANTHEON)) {
       return Bytes.concatenate(Bytes.wrap(groupId), Bytes.wrap(seed)).toArray();
     } else {
       return groupId;

--- a/src/main/java/net/consensys/orion/http/handler/privacy/PrivacyGroupRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/PrivacyGroupRequest.java
@@ -66,6 +66,6 @@ public class PrivacyGroupRequest implements Serializable {
   }
 
   public Optional<byte[]> getSeed() {
-    return Optional.of(seed);
+    return Optional.ofNullable(seed);
   }
 }

--- a/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
+++ b/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
@@ -49,14 +49,7 @@ public class PrivacyGroupStorage implements Storage<PrivacyGroupPayload> {
   @Override
   public String generateDigest(PrivacyGroupPayload data) {
     Box.PublicKey[] addresses = Arrays.stream(data.addresses()).map(enclave::readKey).toArray(Box.PublicKey[]::new);
-    // concatenate the PrivacyGroupId with a random seed
-    if (data.type().equals(PrivacyGroupPayload.Type.PANTHEON)) {
-      Bytes bytes =
-          Bytes.concatenate(Bytes.wrap(enclave.generatePrivacyGroupId(addresses)), Bytes.wrap(data.randomSeed()));
-      return encodeBytes(bytes.toArray());
-    } else {
-      return encodeBytes(enclave.generatePrivacyGroupId(addresses));
-    }
+    return encodeBytes(enclave.generatePrivacyGroupId(addresses, data.randomSeed(), data.type()));
   }
 
 

--- a/src/test/java/net/consensys/orion/enclave/PrivacyGroupGenerationTest.java
+++ b/src/test/java/net/consensys/orion/enclave/PrivacyGroupGenerationTest.java
@@ -68,7 +68,9 @@ public class PrivacyGroupGenerationTest {
       for (PrivacyGroupTest privacyGroup : privacyGroups) {
         Box.PublicKey[] addresses =
             Arrays.stream(privacyGroup.getPrivacyGroup()).map(enclave::readKey).toArray(Box.PublicKey[]::new);
-        assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(enclave.generatePrivacyGroupId(addresses)));
+        assertEquals(
+            privacyGroup.getPrivacyGroupId(),
+            encodeBytes(enclave.generatePrivacyGroupId(addresses, null, PrivacyGroupPayload.Type.LEGACY)));
 
       }
     } catch (IOException e) {

--- a/src/test/java/net/consensys/orion/enclave/sodium/SodiumEnclaveStub.java
+++ b/src/test/java/net/consensys/orion/enclave/sodium/SodiumEnclaveStub.java
@@ -16,6 +16,7 @@ import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.EncryptedKey;
 import net.consensys.orion.enclave.EncryptedPayload;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -49,7 +50,7 @@ public class SodiumEnclaveStub implements Enclave {
   }
 
   @Override
-  public EncryptedPayload encrypt(byte[] plaintext, Box.PublicKey senderKey, Box.PublicKey[] recipients) {
+  public EncryptedPayload encrypt(byte[] plaintext, Box.PublicKey senderKey, Box.PublicKey[] recipients, byte[] seed) {
     byte[] cipherText = new byte[plaintext.length];
     for (int i = 0; i < plaintext.length; i++) {
       byte b = plaintext[i];
@@ -60,11 +61,14 @@ public class SodiumEnclaveStub implements Enclave {
         new byte[0],
         new EncryptedKey[0],
         cipherText,
-        generatePrivacyGroupId(recipients));
+        generatePrivacyGroupId(recipients, seed, PrivacyGroupPayload.Type.PANTHEON));
   }
 
   @Override
-  public byte[] generatePrivacyGroupId(Box.PublicKey[] recipientsAndSender) {
+  public byte[] generatePrivacyGroupId(
+      Box.PublicKey[] recipientsAndSender,
+      byte[] seed,
+      PrivacyGroupPayload.Type type) {
     return new byte[0];
   }
 }

--- a/src/test/java/net/consensys/orion/enclave/sodium/SodiumEnclaveStubTest.java
+++ b/src/test/java/net/consensys/orion/enclave/sodium/SodiumEnclaveStubTest.java
@@ -27,7 +27,7 @@ class SodiumEnclaveStubTest {
   void roundTripEncryption() {
     byte[] message = "hello".getBytes(UTF_8);
     SodiumEnclaveStub enclave = new SodiumEnclaveStub();
-    EncryptedPayload encryptedPayload = enclave.encrypt(message, null, null);
+    EncryptedPayload encryptedPayload = enclave.encrypt(message, null, null, null);
     byte[] bytes = enclave.decrypt(encryptedPayload, null);
     assertArrayEquals(message, bytes);
   }
@@ -36,7 +36,7 @@ class SodiumEnclaveStubTest {
   void roundTripEncryptionWithFunkyBytes() {
     byte[] message = DatatypeConverter.parseHexBinary("0079FF00FF89");
     SodiumEnclaveStub enclave = new SodiumEnclaveStub();
-    EncryptedPayload encryptedPayload = enclave.encrypt(message, null, null);
+    EncryptedPayload encryptedPayload = enclave.encrypt(message, null, null, null);
     byte[] bytes = enclave.decrypt(encryptedPayload, null);
     assertArrayEquals(message, bytes);
   }

--- a/src/test/java/net/consensys/orion/enclave/sodium/SodiumEnclaveTest.java
+++ b/src/test/java/net/consensys/orion/enclave/sodium/SodiumEnclaveTest.java
@@ -168,6 +168,6 @@ class SodiumEnclaveTest {
   }
 
   private EncryptedPayload encrypt(String plaintext, Box.PublicKey senderKey, Box.PublicKey... recipientKey) {
-    return enclave.encrypt(plaintext.getBytes(UTF_8), senderKey, recipientKey);
+    return enclave.encrypt(plaintext.getBytes(UTF_8), senderKey, recipientKey, null);
   }
 }

--- a/src/test/java/net/consensys/orion/helpers/StubEnclave.java
+++ b/src/test/java/net/consensys/orion/helpers/StubEnclave.java
@@ -16,6 +16,7 @@ import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.EncryptedKey;
 import net.consensys.orion.enclave.EncryptedPayload;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -67,7 +68,7 @@ public class StubEnclave implements Enclave {
   }
 
   @Override
-  public EncryptedPayload encrypt(byte[] plaintext, Box.PublicKey senderKey, Box.PublicKey[] recipients) {
+  public EncryptedPayload encrypt(byte[] plaintext, Box.PublicKey senderKey, Box.PublicKey[] recipients, byte[] seed) {
     byte[] ciphterText = new byte[plaintext.length];
     for (int i = 0; i < plaintext.length; i++) {
       byte b = plaintext[i];
@@ -100,11 +101,14 @@ public class StubEnclave implements Enclave {
         encryptedKeys,
         ciphterText,
         encryptedKeyOwners,
-        generatePrivacyGroupId(keys.toArray(new Box.PublicKey[0])));
+        generatePrivacyGroupId(keys.toArray(new Box.PublicKey[0]), seed, PrivacyGroupPayload.Type.PANTHEON));
   }
 
   @Override
-  public byte[] generatePrivacyGroupId(Box.PublicKey[] recipientsAndSender) {
+  public byte[] generatePrivacyGroupId(
+      Box.PublicKey[] recipientsAndSender,
+      byte[] seed,
+      PrivacyGroupPayload.Type type) {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
     for (int i = 0; recipientsAndSender != null && i < recipientsAndSender.length; i++) {

--- a/src/test/java/net/consensys/orion/http/handler/DeletePrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/DeletePrivacyGroupHandlerTest.java
@@ -16,7 +16,6 @@ import static net.consensys.cava.io.Base64.encodeBytes;
 import static net.consensys.orion.http.server.HttpContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.PrivacyGroupPayload;
@@ -29,7 +28,6 @@ import net.consensys.orion.http.handler.privacy.PrivacyGroupRequest;
 import net.consensys.orion.utils.Serializer;
 
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 

--- a/src/test/java/net/consensys/orion/http/handler/DeletePrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/DeletePrivacyGroupHandlerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 import net.consensys.orion.enclave.sodium.MemoryKeyStore;
 import net.consensys.orion.enclave.sodium.SodiumEnclave;
 import net.consensys.orion.helpers.FakePeer;
@@ -28,6 +29,7 @@ import net.consensys.orion.http.handler.privacy.PrivacyGroupRequest;
 import net.consensys.orion.utils.Serializer;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 
@@ -62,12 +64,13 @@ public class DeletePrivacyGroupHandlerTest extends HandlerTest {
         buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), "test", "desc");
     Request request = buildPrivateAPIRequest("/privacyGroupId", JSON, privacyGroupRequestExpected);
 
-    Bytes privacyGroupPayload = Bytes.concatenate(
-        Bytes.wrap(enclave.generatePrivacyGroupId(new Box.PublicKey[] {senderKey, recipientKey})),
-        Bytes.wrap(privacyGroupRequestExpected.getSeed().get()));
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        new Box.PublicKey[] {senderKey, recipientKey},
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
 
     // create fake peer
-    fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload.toArray())), recipientKey);
+    fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
     networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
 
     // execute request

--- a/src/test/java/net/consensys/orion/http/handler/PrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/PrivacyGroupHandlerTest.java
@@ -16,9 +16,9 @@ import static net.consensys.cava.io.Base64.encodeBytes;
 import static net.consensys.orion.http.server.HttpContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 import net.consensys.orion.enclave.sodium.MemoryKeyStore;
 import net.consensys.orion.enclave.sodium.SodiumEnclave;
 import net.consensys.orion.http.handler.privacy.PrivacyGroup;
@@ -60,13 +60,13 @@ public class PrivacyGroupHandlerTest extends HandlerTest {
         buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), "test", "desc");
     Request request = buildPrivateAPIRequest("/privacyGroupId", JSON, privacyGroupRequestExpected);
 
-    Bytes privacyGroupPayload = Bytes.concatenate(
-        Bytes.wrap(enclave.generatePrivacyGroupId(addresses)),
-        Bytes.wrap(privacyGroupRequestExpected.getSeed().get()));
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        addresses,
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
 
     // create fake peer
-    FakePeer fakePeer =
-        new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload.toArray())), recipientKey);
+    FakePeer fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
     networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
 
     // execute request
@@ -77,7 +77,7 @@ public class PrivacyGroupHandlerTest extends HandlerTest {
 
     PrivacyGroup privacyGroup = Serializer.deserialize(JSON, PrivacyGroup.class, resp.body().bytes());
 
-    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload.toArray()));
+    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload));
   }
 
   @Test
@@ -98,22 +98,19 @@ public class PrivacyGroupHandlerTest extends HandlerTest {
         buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), "test", "desc");
     Request request = buildPrivateAPIRequest("/privacyGroupId", JSON, privacyGroupRequestExpected);
 
-
-    Bytes privacyGroupPayload = Bytes.concatenate(
-        Bytes.wrap(enclave.generatePrivacyGroupId(addresses)),
-        Bytes.wrap(privacyGroupRequestExpected.getSeed().get()));
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        addresses,
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
 
     // create fake peers
-    FakePeer fakePeer1 =
-        new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload.toArray())), recipientKey1);
+    FakePeer fakePeer1 = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey1);
     networkNodes.addNode(fakePeer1.publicKey, fakePeer1.getURL());
 
-    FakePeer fakePeer2 =
-        new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload.toArray())), recipientKey2);
+    FakePeer fakePeer2 = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey2);
     networkNodes.addNode(fakePeer2.publicKey, fakePeer2.getURL());
 
-    FakePeer fakePeer3 =
-        new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload.toArray())), recipientKey3);
+    FakePeer fakePeer3 = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey3);
     networkNodes.addNode(fakePeer3.publicKey, fakePeer3.getURL());
 
     // execute request
@@ -123,7 +120,7 @@ public class PrivacyGroupHandlerTest extends HandlerTest {
 
     PrivacyGroup privacyGroup = Serializer.deserialize(JSON, PrivacyGroup.class, resp.body().bytes());
 
-    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload.toArray()));
+    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload));
   }
 
   @Test
@@ -143,13 +140,13 @@ public class PrivacyGroupHandlerTest extends HandlerTest {
         buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), "test", "desc");
     Request request = buildPrivateAPIRequest("/privacyGroupId", JSON, privacyGroupRequestExpected);
 
-    Bytes privacyGroupPayload = Bytes.concatenate(
-        Bytes.wrap(enclave.generatePrivacyGroupId(addresses)),
-        Bytes.wrap(privacyGroupRequestExpected.getSeed().get()));
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        addresses,
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
 
     // create fake peer
-    FakePeer fakePeer =
-        new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload.toArray())), recipientKey);
+    FakePeer fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
     networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
 
     // execute request
@@ -159,7 +156,7 @@ public class PrivacyGroupHandlerTest extends HandlerTest {
 
     PrivacyGroup privacyGroup = Serializer.deserialize(JSON, PrivacyGroup.class, resp.body().bytes());
 
-    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload.toArray()));
+    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload));
   }
 
   PrivacyGroupRequest buildPrivacyGroupRequest(String[] addresses, String from, String name, String description) {

--- a/src/test/java/net/consensys/orion/http/handler/PushHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/PushHandlerTest.java
@@ -110,6 +110,6 @@ class PushHandlerTest extends HandlerTest {
     SodiumEnclave sEnclave = new SodiumEnclave(memoryKeyStore);
     Box.PublicKey k1 = memoryKeyStore.generateKeyPair();
     Box.PublicKey k2 = memoryKeyStore.generateKeyPair();
-    return sEnclave.encrypt("something important".getBytes(UTF_8), k1, new Box.PublicKey[] {k2});
+    return sEnclave.encrypt("something important".getBytes(UTF_8), k1, new Box.PublicKey[] {k2}, null);
   }
 }

--- a/src/test/java/net/consensys/orion/http/handler/ReceiveHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/ReceiveHandlerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.EncryptedPayload;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
 import net.consensys.orion.enclave.sodium.MemoryKeyStore;
 import net.consensys.orion.enclave.sodium.SodiumEnclave;
 import net.consensys.orion.exception.OrionErrorCode;
@@ -137,7 +138,7 @@ class ReceiveHandlerTest extends HandlerTest {
 
     // encrypt a payload
     Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
-    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, enclave.nodeKeys());
+    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, enclave.nodeKeys(), null);
 
     // store it
     String key = payloadStorage.put(originalPayload).get();
@@ -183,7 +184,7 @@ class ReceiveHandlerTest extends HandlerTest {
 
     // encrypt a payload
     Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
-    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, enclave.nodeKeys());
+    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, enclave.nodeKeys(), null);
 
     // store it
     String key = payloadStorage.put(originalPayload).get();
@@ -222,7 +223,7 @@ class ReceiveHandlerTest extends HandlerTest {
     new Random().nextBytes(toEncrypt);
 
     Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
-    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, new Box.PublicKey[] {senderKey});
+    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, new Box.PublicKey[] {senderKey}, null);
 
     String key = payloadStorage.put(originalPayload).get();
     RequestBody body = RequestBody.create(MediaType.parse(APPLICATION_OCTET_STREAM.httpHeaderValue), "");
@@ -294,7 +295,7 @@ class ReceiveHandlerTest extends HandlerTest {
       Box.PublicKey senderKey,
       Box.PublicKey[] recipientKeys) throws Exception {
     // encrypt a payload
-    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, recipientKeys);
+    EncryptedPayload originalPayload = enclave.encrypt(toEncrypt, senderKey, recipientKeys, null);
 
     // store it
     String key = storage.put(originalPayload).get();
@@ -307,6 +308,6 @@ class ReceiveHandlerTest extends HandlerTest {
     Box.PublicKey[] tempArray = new Box.PublicKey[recipient.length + 1];
     System.arraycopy(recipient, 0, tempArray, 0, recipient.length);
     tempArray[recipient.length] = sender;
-    return enclave.generatePrivacyGroupId(tempArray);
+    return enclave.generatePrivacyGroupId(tempArray, null, PrivacyGroupPayload.Type.LEGACY);
   }
 }

--- a/src/test/java/net/consensys/orion/http/handler/SendHandlerWithNodeKeysTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/SendHandlerWithNodeKeysTest.java
@@ -61,7 +61,7 @@ class SendHandlerWithNodeKeysTest extends SendHandlerTest {
     new Random().nextBytes(toEncrypt);
 
     // encrypt it here to compute digest
-    EncryptedPayload encryptedPayload = enclave.encrypt(toEncrypt, null, null);
+    EncryptedPayload encryptedPayload = enclave.encrypt(toEncrypt, null, null, null);
     String digest = encodeBytes(sha2_512_256(encryptedPayload.cipherText()));
 
     // create fake peer

--- a/src/test/java/net/consensys/orion/storage/EncryptedPayloadStorageTest.java
+++ b/src/test/java/net/consensys/orion/storage/EncryptedPayloadStorageTest.java
@@ -42,7 +42,7 @@ class EncryptedPayloadStorageTest {
     byte[] toEncrypt = new byte[342];
     new Random().nextBytes(toEncrypt);
 
-    EncryptedPayload toStore = enclave.encrypt(toEncrypt, null, null);
+    EncryptedPayload toStore = enclave.encrypt(toEncrypt, null, null, null);
 
     String key = payloadStorage.put(toStore).get();
     assertEquals(toStore, payloadStorage.get(key).get().get());


### PR DESCRIPTION
To incorporate the random seed used in generation of privacy group, we need to pass in the seed every time we need to generate it. 
Including when encrypting the payload, generating privacy group or propagating the payload. 

This change keeps the generation consistent to ensure that correct privacy group is used.