### PR TITLE
Publish source and javadoc to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,16 @@ sourceSets {
   }
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  from javadoc.destinationDir
+}
+
 task acceptanceTest(type: Test) {
   description = 'Runs the acceptance tests'
   group = 'verification'
@@ -350,6 +360,8 @@ publishing {
   publications {
     mavenArtifact(MavenPublication) {
       from components.java
+	  artifact sourcesJar
+	  artifact javadocJar
       pom.withXml {
         asNode().children().last() + {
           resolveStrategy = Closure.DELEGATE_FIRST

--- a/build.gradle
+++ b/build.gradle
@@ -360,8 +360,8 @@ publishing {
   publications {
     mavenArtifact(MavenPublication) {
       from components.java
-	  artifact sourcesJar
-	  artifact javadocJar
+      artifact sourcesJar
+      artifact javadocJar
       pom.withXml {
         asNode().children().last() + {
           resolveStrategy = Closure.DELEGATE_FIRST


### PR DESCRIPTION
Include source and java doc jars when publishing artefacts to bintray.