### PR TITLE
[PAN-2752] Add findPrivacyGroup endpoint

### DIFF
--- a/src/acceptance-test/java/net/consensys/orion/acceptance/EthClientStub.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/EthClientStub.java
@@ -15,6 +15,11 @@ package net.consensys.orion.acceptance;
 import static net.consensys.cava.io.Base64.decodeBytes;
 import static net.consensys.orion.http.server.HttpContentType.JSON;
 
+import net.consensys.orion.http.handler.privacy.DeletePrivacyGroupRequest;
+import net.consensys.orion.http.handler.privacy.FindPrivacyGroupRequest;
+import net.consensys.orion.http.handler.privacy.FindPrivacyGroupResponse;
+import net.consensys.orion.http.handler.privacy.PrivacyGroup;
+import net.consensys.orion.http.handler.privacy.PrivacyGroupRequest;
 import net.consensys.orion.http.handler.receive.ReceiveRequest;
 import net.consensys.orion.http.handler.receive.ReceiveResponse;
 import net.consensys.orion.utils.Serializer;
@@ -117,6 +122,51 @@ public class EthClientStub {
         .putHeader("Content-Type", "application/vnd.orion.v1+json")
         .end(Buffer.buffer(Serializer.serialize(JSON, receiveRequest)));
     return payloadFuture.join();
+  }
+
+  public Optional<PrivacyGroup> createPrivacyGroup(String[] addresses, String from, String name, String description) {
+    PrivacyGroupRequest createGroupRequest = new PrivacyGroupRequest(addresses, from, name, description);
+    CompletableFuture<PrivacyGroup> keyFuture = new CompletableFuture<>();
+    httpClient.post(clientPort, "localhost", "/privacyGroupId").handler(resp -> {
+      if (resp.statusCode() == 200) {
+        resp.bodyHandler(body -> keyFuture.complete(deserialize(body, PrivacyGroup.class)));
+      } else {
+        keyFuture.complete(null);
+      }
+    }).exceptionHandler(keyFuture::completeExceptionally).putHeader("Content-Type", "application/json").end(
+        Buffer.buffer(Serializer.serialize(JSON, createGroupRequest)));
+    return Optional.ofNullable(keyFuture.join());
+  }
+
+  public Optional<FindPrivacyGroupResponse[]> findPrivacyGroup(String[] addresses) {
+    FindPrivacyGroupRequest findGroupRequest = new FindPrivacyGroupRequest(addresses);
+    CompletableFuture<FindPrivacyGroupResponse[]> keyFuture = new CompletableFuture<>();
+    httpClient.post(clientPort, "localhost", "/findPrivacyGroupId").handler(resp -> {
+      if (resp.statusCode() == 200) {
+        resp.bodyHandler(body -> keyFuture.complete(deserialize(body, FindPrivacyGroupResponse[].class)));
+      } else {
+        keyFuture.complete(null);
+      }
+    }).exceptionHandler(keyFuture::completeExceptionally).putHeader("Content-Type", "application/json").end(
+        Buffer.buffer(Serializer.serialize(JSON, findGroupRequest)));
+    return Optional.ofNullable(keyFuture.join());
+  }
+
+  public Optional<String> deletePrivacyGroup(String privacyGroupId, String from) {
+    DeletePrivacyGroupRequest deleteGroupRequest = new DeletePrivacyGroupRequest(privacyGroupId, from);
+    CompletableFuture<String> keyFuture = new CompletableFuture<>();
+    httpClient.post(clientPort, "localhost", "/deletePrivacyGroupId").handler(resp -> {
+      if (resp.statusCode() == 200) {
+        resp.bodyHandler((body) -> {
+          String res = deserialize(body, String.class);
+          keyFuture.complete(res);
+        });
+      } else {
+        keyFuture.complete(null);
+      }
+    }).exceptionHandler(keyFuture::completeExceptionally).putHeader("Content-Type", "application/json").end(
+        Buffer.buffer(Serializer.serialize(JSON, deleteGroupRequest)));
+    return Optional.ofNullable(keyFuture.join());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/EthClientStub.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/EthClientStub.java
@@ -66,6 +66,20 @@ public class EthClientStub {
     return Optional.ofNullable(keyFuture.join());
   }
 
+  public Optional<String> sendExpectingError(byte[] payload, String from, String[] to) {
+    Map<String, Object> sendRequest = sendRequest(payload, from, to);
+    CompletableFuture<String> keyFuture = new CompletableFuture<>();
+    httpClient.post(clientPort, "localhost", "/send").handler(resp -> {
+      if (resp.statusCode() != 200) {
+        resp.bodyHandler(body -> keyFuture.complete(body.toString()));
+      } else {
+        keyFuture.complete(null);
+      }
+    }).exceptionHandler(keyFuture::completeExceptionally).putHeader("Content-Type", "application/json").end(
+        Buffer.buffer(Serializer.serialize(JSON, sendRequest)));
+    return Optional.ofNullable(keyFuture.join());
+  }
+
   Optional<String> send(byte[] payload, String from, String privacyGroupId) {
     Map<String, Object> sendRequest = sendRequest(payload, from, privacyGroupId);
     CompletableFuture<String> keyFuture = new CompletableFuture<>();
@@ -80,8 +94,8 @@ public class EthClientStub {
     return Optional.ofNullable(keyFuture.join());
   }
 
-  public Optional<String> sendExpectingError(byte[] payload, String from, String[] to) {
-    Map<String, Object> sendRequest = sendRequest(payload, from, to);
+  public Optional<String> sendPrivacyExpectingError(byte[] payload, String from, String privacyGroupId) {
+    Map<String, Object> sendRequest = sendRequest(payload, from, privacyGroupId);
     CompletableFuture<String> keyFuture = new CompletableFuture<>();
     httpClient.post(clientPort, "localhost", "/send").handler(resp -> {
       if (resp.statusCode() != 200) {

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/NodeUtils.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/NodeUtils.java
@@ -18,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.consensys.orion.cmd.Orion;
 import net.consensys.orion.config.Config;
+import net.consensys.orion.http.handler.privacy.FindPrivacyGroupResponse;
+import net.consensys.orion.http.handler.privacy.PrivacyGroup;
 import net.consensys.orion.http.handler.receive.ReceiveResponse;
 
 import java.io.IOException;
@@ -127,6 +129,23 @@ public class NodeUtils {
 
   public static String sendTransactionPrivacyGroupId(EthClientStub sender, String senderKey, String privacyGroupId) {
     return sender.send(originalPayload, senderKey, privacyGroupId).orElseThrow(AssertionFailedError::new);
+  }
+
+  public static PrivacyGroup createPrivacyGroupTransaction(
+      EthClientStub sender,
+      String[] addresses,
+      String from,
+      String name,
+      String description) {
+    return sender.createPrivacyGroup(addresses, from, name, description).orElseThrow(AssertionFailedError::new);
+  }
+
+  public static FindPrivacyGroupResponse[] findPrivacyGroupTransaction(EthClientStub sender, String[] addresses) {
+    return sender.findPrivacyGroup(addresses).orElseThrow(AssertionFailedError::new);
+  }
+
+  public static String deletePrivacyGroupTransaction(EthClientStub sender, String privacyGroupId, String from) {
+    return sender.deletePrivacyGroup(privacyGroupId, from).orElseThrow(AssertionFailedError::new);
   }
 
   /** Asserts the received payload matches that sent. */

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesPrivacyGroupsTest.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesPrivacyGroupsTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.acceptance.send.receive.privacyGroup;
+
+import static io.vertx.core.Vertx.vertx;
+import static net.consensys.cava.io.Base64.decodeBytes;
+import static net.consensys.cava.io.file.Files.copyResource;
+import static net.consensys.orion.acceptance.NodeUtils.createPrivacyGroupTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.deletePrivacyGroupTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.findPrivacyGroupTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.joinPathsAsTomlListEntry;
+import static net.consensys.orion.http.server.HttpContentType.CBOR;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.cava.junit.TempDirectory;
+import net.consensys.cava.junit.TempDirectoryExtension;
+import net.consensys.orion.acceptance.EthClientStub;
+import net.consensys.orion.acceptance.NodeUtils;
+import net.consensys.orion.cmd.Orion;
+import net.consensys.orion.config.Config;
+import net.consensys.orion.http.handler.privacy.FindPrivacyGroupResponse;
+import net.consensys.orion.http.handler.privacy.PrivacyGroup;
+import net.consensys.orion.http.server.HttpContentType;
+import net.consensys.orion.network.ConcurrentNetworkNodes;
+import net.consensys.orion.utils.Serializer;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Runs up a two nodes that communicates with each other. */
+@ExtendWith(TempDirectoryExtension.class)
+class DualNodesPrivacyGroupsTest {
+
+  private static final String PK_1_B_64 = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
+  private static final String PK_2_B_64 = "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=";
+
+  private Config firstNodeConfig;
+  private Config secondNodeConfig;
+  private ConcurrentNetworkNodes networkNodes;
+
+  private Orion firstOrionLauncher;
+  private Orion secondOrionLauncher;
+  private Vertx vertx;
+  private HttpClient firstHttpClient;
+  private HttpClient secondHttpClient;
+
+  @BeforeEach
+  void setUpDualNodes(@TempDirectory Path tempDir) throws Exception {
+
+    Path key1pub = copyResource("key1.pub", tempDir.resolve("key1.pub"));
+    Path key1key = copyResource("key1.key", tempDir.resolve("key1.key"));
+    Path key2pub = copyResource("key2.pub", tempDir.resolve("key2.pub"));
+    Path key2key = copyResource("key2.key", tempDir.resolve("key2.key"));
+    String jdbcUrl = "jdbc:h2:" + tempDir.resolve("node2").toString();
+    try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+      Statement st = conn.createStatement();
+      st.executeUpdate("create table if not exists store(key binary, value binary, primary key(key))");
+    }
+
+    firstNodeConfig = NodeUtils.nodeConfig(
+        tempDir,
+        0,
+        "127.0.0.1",
+        0,
+        "127.0.0.1",
+        "node1",
+        joinPathsAsTomlListEntry(key1pub),
+        joinPathsAsTomlListEntry(key1key),
+        "off",
+        "tofu",
+        "tofu",
+        "leveldb:database/node1");
+    secondNodeConfig = NodeUtils.nodeConfig(
+        tempDir,
+        0,
+        "127.0.0.1",
+        0,
+        "127.0.0.1",
+        "node2",
+        joinPathsAsTomlListEntry(key2pub),
+        joinPathsAsTomlListEntry(key2key),
+        "off",
+        "tofu",
+        "tofu",
+        "sql:" + jdbcUrl);
+
+    vertx = vertx();
+    firstOrionLauncher = NodeUtils.startOrion(firstNodeConfig);
+    firstHttpClient = vertx.createHttpClient();
+    secondOrionLauncher = NodeUtils.startOrion(secondNodeConfig);
+    secondHttpClient = vertx.createHttpClient();
+    Box.PublicKey pk1 = Box.PublicKey.fromBytes(decodeBytes(PK_1_B_64));
+    Box.PublicKey pk2 = Box.PublicKey.fromBytes(decodeBytes(PK_2_B_64));
+    networkNodes = new ConcurrentNetworkNodes(NodeUtils.url("127.0.0.1", firstOrionLauncher.nodePort()));
+
+    networkNodes.addNode(pk1, NodeUtils.url("127.0.0.1", firstOrionLauncher.nodePort()));
+    networkNodes.addNode(pk2, NodeUtils.url("127.0.0.1", secondOrionLauncher.nodePort()));
+    // prepare /partyinfo payload (our known peers)
+    RequestBody partyInfoBody =
+        RequestBody.create(MediaType.parse(CBOR.httpHeaderValue), Serializer.serialize(CBOR, networkNodes));
+    // call http endpoint
+    OkHttpClient httpClient = new OkHttpClient();
+
+    final String firstNodeBaseUrl = NodeUtils.urlString("127.0.0.1", firstOrionLauncher.nodePort());
+    Request request = new Request.Builder().post(partyInfoBody).url(firstNodeBaseUrl + "/partyinfo").build();
+    // first /partyinfo call may just get the one node, so wait until we get at least 2 nodes
+    await().atMost(5, TimeUnit.SECONDS).until(() -> getPartyInfoResponse(httpClient, request).nodeURLs().size() == 2);
+
+  }
+
+  private ConcurrentNetworkNodes getPartyInfoResponse(OkHttpClient httpClient, Request request) throws Exception {
+    Response resp = httpClient.newCall(request).execute();
+    assertEquals(200, resp.code());
+
+    ConcurrentNetworkNodes partyInfoResponse =
+        Serializer.deserialize(HttpContentType.CBOR, ConcurrentNetworkNodes.class, resp.body().bytes());
+    return partyInfoResponse;
+  }
+
+  @AfterEach
+  void tearDown() {
+    firstOrionLauncher.stop();
+    secondOrionLauncher.stop();
+    vertx.close();
+  }
+
+  @Test
+  void createAndFind() {
+    final EthClientStub firstNode = NodeUtils.client(firstOrionLauncher.clientPort(), firstHttpClient);
+    final EthClientStub secondNode = NodeUtils.client(secondOrionLauncher.clientPort(), secondHttpClient);
+
+    String name = "testName";
+    String description = "testDescription";
+    String[] addresses = new String[] {PK_1_B_64, PK_2_B_64};
+    // create a privacy group
+    final PrivacyGroup privacyGroup = createPrivacyGroupTransaction(firstNode, addresses, PK_1_B_64, name, description);
+
+    String privacyGroupId = privacyGroup.getPrivacyGroupId();
+    assertEquals(privacyGroup.getName(), name);
+    assertEquals(privacyGroup.getDescription(), description);
+
+    // find the created privacy group in first node
+    final FindPrivacyGroupResponse[] firstNodePrivacyGroups = findPrivacyGroupTransaction(firstNode, addresses);
+
+    assertEquals(firstNodePrivacyGroups.length, 1);
+    assertEquals(firstNodePrivacyGroups[0].privacyGroupId(), privacyGroupId);
+
+    // find the created privacy group in second node
+    final FindPrivacyGroupResponse[] secondNodePrivacyGroups = findPrivacyGroupTransaction(secondNode, addresses);
+
+    assertEquals(secondNodePrivacyGroups.length, firstNodePrivacyGroups.length);
+    assertEquals(secondNodePrivacyGroups[0].privacyGroupId(), firstNodePrivacyGroups[0].privacyGroupId());
+  }
+
+  @Test
+  void createDeleteFind() {
+    final EthClientStub firstNode = NodeUtils.client(firstOrionLauncher.clientPort(), firstHttpClient);
+    final EthClientStub secondNode = NodeUtils.client(secondOrionLauncher.clientPort(), secondHttpClient);
+
+    String name = "testName";
+    String description = "testDescription";
+    String[] addresses = new String[] {PK_1_B_64, PK_2_B_64};
+    // create a privacy group
+    final PrivacyGroup privacyGroup = createPrivacyGroupTransaction(firstNode, addresses, PK_1_B_64, name, description);
+
+    String privacyGroupId = privacyGroup.getPrivacyGroupId();
+    assertEquals(privacyGroup.getName(), name);
+    assertEquals(privacyGroup.getDescription(), description);
+
+    // delete privacy group
+    String privacyGroupDeleted = deletePrivacyGroupTransaction(firstNode, privacyGroupId, PK_1_B_64);
+
+    // find the created privacy group deleted in first node
+    final FindPrivacyGroupResponse[] deleteNodeFirstPrivacyGroups = findPrivacyGroupTransaction(firstNode, addresses);
+
+    List<String> listFirst =
+        Arrays.stream(deleteNodeFirstPrivacyGroups).map(FindPrivacyGroupResponse::privacyGroupId).collect(
+            Collectors.toList());
+    assertFalse(listFirst.contains(privacyGroupDeleted));
+
+    // find the deleted privacy group in second node
+    final FindPrivacyGroupResponse[] deleteNodeSecondPrivacyGroups = findPrivacyGroupTransaction(secondNode, addresses);
+
+    List<String> listSecond =
+        Arrays.stream(deleteNodeSecondPrivacyGroups).map(FindPrivacyGroupResponse::privacyGroupId).collect(
+            Collectors.toList());
+    assertFalse(listSecond.contains(privacyGroupDeleted));
+  }
+
+
+  @Test
+  void createTwiceDeleteOnce() {
+    final EthClientStub firstNode = NodeUtils.client(firstOrionLauncher.clientPort(), firstHttpClient);
+    final EthClientStub secondNode = NodeUtils.client(secondOrionLauncher.clientPort(), secondHttpClient);
+
+    String name = "testName";
+    String description = "testDescription";
+    String[] addresses = new String[] {PK_1_B_64, PK_2_B_64};
+
+    // create a privacy group
+    PrivacyGroup firstPrivacyGroup = createPrivacyGroupTransaction(firstNode, addresses, PK_1_B_64, name, description);
+
+    String firstPrivacyGroupId = firstPrivacyGroup.getPrivacyGroupId();
+    assertEquals(firstPrivacyGroup.getName(), name);
+    assertEquals(firstPrivacyGroup.getDescription(), description);
+
+    // find the created privacy group in first node
+    FindPrivacyGroupResponse[] initialPrivacyGroups = findPrivacyGroupTransaction(firstNode, addresses);
+    assertEquals(initialPrivacyGroups.length, 1);
+    assertEquals(initialPrivacyGroups[0].privacyGroupId(), firstPrivacyGroupId);
+
+    //create another privacy group
+    PrivacyGroup secondPrivacyGroup = createPrivacyGroupTransaction(firstNode, addresses, PK_1_B_64, name, description);
+
+    String secondPrivacyGroupId = secondPrivacyGroup.getPrivacyGroupId();
+    assertEquals(firstPrivacyGroup.getName(), name);
+    assertEquals(firstPrivacyGroup.getDescription(), description);
+
+    // find the created privacy group in first node
+    FindPrivacyGroupResponse[] updatedPrivacyGroups = findPrivacyGroupTransaction(secondNode, addresses);
+    assertEquals(updatedPrivacyGroups.length, 2);
+    assertEquals(updatedPrivacyGroups[0].privacyGroupId(), firstPrivacyGroupId);
+    assertEquals(updatedPrivacyGroups[1].privacyGroupId(), secondPrivacyGroupId);
+
+    // delete the first privacy group
+    deletePrivacyGroupTransaction(firstNode, firstPrivacyGroupId, PK_1_B_64);
+
+    // find the deleted privacy group in second node
+    final FindPrivacyGroupResponse[] deleteNodeSecondPrivacyGroups = findPrivacyGroupTransaction(secondNode, addresses);
+
+    List<String> listSecond =
+        Arrays.stream(deleteNodeSecondPrivacyGroups).map(FindPrivacyGroupResponse::privacyGroupId).collect(
+            Collectors.toList());
+    assertFalse(listSecond.contains(firstPrivacyGroupId));
+    assertTrue(listSecond.contains(secondPrivacyGroupId));
+  }
+
+  @Test
+  void createAndDeleteTwice() {
+
+  }
+}

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -149,7 +149,7 @@ public class Orion {
         new PushHandler(storage));
 
     nodeRouter.post("/pushPrivacyGroup").produces(TEXT.httpHeaderValue).consumes(CBOR.httpHeaderValue).handler(
-        new PushPrivacyGroupHandler(privacyGroupStorage));
+        new PushPrivacyGroupHandler(privacyGroupStorage, queryPrivacyGroupStorage));
 
     //Setup client APIs
     clientRouter

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -24,7 +24,6 @@ import net.consensys.cava.crypto.sodium.Sodium;
 import net.consensys.cava.kv.KeyValueStore;
 import net.consensys.cava.kv.LevelDBKeyValueStore;
 import net.consensys.cava.kv.MapDBKeyValueStore;
-import net.consensys.cava.kv.SQLKeyValueStore;
 import net.consensys.cava.net.tls.VertxTrustOptions;
 import net.consensys.orion.config.Config;
 import net.consensys.orion.config.ConfigException;
@@ -47,6 +46,7 @@ import net.consensys.orion.http.server.vertx.HttpErrorHandler;
 import net.consensys.orion.network.ConcurrentNetworkNodes;
 import net.consensys.orion.network.NetworkDiscovery;
 import net.consensys.orion.storage.EncryptedPayloadStorage;
+import net.consensys.orion.storage.OrionSQLKeyValueStore;
 import net.consensys.orion.storage.PrivacyGroupStorage;
 import net.consensys.orion.storage.QueryPrivacyGroupStorage;
 import net.consensys.orion.storage.Sha512_256StorageKeyBuilder;
@@ -62,6 +62,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Security;
+import java.sql.SQLException;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -520,8 +521,10 @@ public class Orion {
       }
     } else if (storage.toLowerCase().startsWith("sql")) {
       try {
-        return SQLKeyValueStore.open(db);
-      } catch (IOException e) {
+        // FIXME: Hack to enable update in SQL.
+        // TODO: Update net.consensys.cava.kv.SQLKeyValueStore to enable updates
+        return new OrionSQLKeyValueStore(db);
+      } catch (IOException | SQLException e) {
         throw new OrionStartException("Couldn't create SQL-backed store: " + db, e);
       }
     } else {

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -209,7 +209,7 @@ public class Orion {
             config));
 
     clientRouter.post("/findPrivacyGroupId").consumes(JSON.httpHeaderValue).produces(JSON.httpHeaderValue).handler(
-        new FindPrivacyGroupHandler(queryPrivacyGroupStorage, enclave));
+        new FindPrivacyGroupHandler(queryPrivacyGroupStorage, privacyGroupStorage, enclave));
   }
 
   public Orion() {

--- a/src/main/java/net/consensys/orion/enclave/QueryPrivacyGroupPayload.java
+++ b/src/main/java/net/consensys/orion/enclave/QueryPrivacyGroupPayload.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.enclave;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+public class QueryPrivacyGroupPayload implements Serializable {
+
+  private final String[] addresses;
+  private final List<String> privacyGroupId;
+  private String privacyGroupToAppend = null;
+
+  private boolean toDelete = false;
+
+  @JsonCreator
+  public QueryPrivacyGroupPayload(
+      @JsonProperty("addresses") String[] addresses,
+      @JsonProperty("privacyGroupId") List<String> privacyGroupId) {
+    this.addresses = addresses;
+    this.privacyGroupId = privacyGroupId;
+  }
+
+  @JsonProperty("addresses")
+  public String[] addresses() {
+    return addresses;
+  }
+
+  @JsonProperty("privacyGroupId")
+  public List<String> privacyGroupId() {
+    return privacyGroupId;
+  }
+
+  @JsonProperty("privacyGroupToAppend")
+  public String privacyGroupToAppend() {
+    return privacyGroupToAppend;
+  }
+
+  @JsonSetter("privacyGroupToAppend")
+  public void setPrivacyGroupToAppend(String privacyGroupToAppend) {
+    this.privacyGroupToAppend = privacyGroupToAppend;
+  }
+
+
+  public boolean isToDelete() {
+    return toDelete;
+  }
+
+  public void setToDelete(boolean toDelete) {
+    this.toDelete = toDelete;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueryPrivacyGroupPayload that = (QueryPrivacyGroupPayload) o;
+    return Arrays.equals(addresses, that.addresses)
+        && Objects.equals(privacyGroupId, that.privacyGroupId)
+        && Objects.equals(privacyGroupToAppend, that.privacyGroupToAppend);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(addresses);
+    result = 31 * result + privacyGroupId.hashCode();
+    result = 31 * result + privacyGroupToAppend.hashCode();
+    return result;
+  }
+}

--- a/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
+++ b/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
@@ -51,7 +51,9 @@ public enum OrionErrorCode {
   ENCLAVE_UNABLE_STORE_PRIVACY_GROUP("PrivacyGroupNotStored"),
   ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP("PrivacyGroupNotDeleted"),
   ENCLAVE_UNABLE_PUSH_DELETE_PRIVACY_GROUP("PrivacyGroupNotPushed"),
-  ENCLAVE_PRIVACY_GROUP_MISSING("PrivacyGroupNotFound");
+  ENCLAVE_PRIVACY_GROUP_MISSING("PrivacyGroupNotFound"),
+  ENCLAVE_PRIVACY_QUERY_ERROR("PrivacyGroupQueryError"),
+  METHOD_UNIMPLEMENTED("MethodUnimplemented");
 
   private final String code;
 

--- a/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.handler.privacy;
+
+import static net.consensys.cava.io.Base64.encodeBytes;
+import static net.consensys.orion.http.server.HttpContentType.JSON;
+
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
+import net.consensys.orion.enclave.QueryPrivacyGroupPayload;
+import net.consensys.orion.exception.OrionErrorCode;
+import net.consensys.orion.exception.OrionException;
+import net.consensys.orion.storage.Storage;
+import net.consensys.orion.utils.Serializer;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Delete the privacy group given the privacyGroupId.
+ */
+public class FindPrivacyGroupHandler implements Handler<RoutingContext> {
+
+  private final Storage<QueryPrivacyGroupPayload> queryPrivacyGroupStorage;
+  private final Enclave enclave;
+
+  public FindPrivacyGroupHandler(Storage<QueryPrivacyGroupPayload> queryPrivacyGroupStorage, Enclave enclave) {
+    this.queryPrivacyGroupStorage = queryPrivacyGroupStorage;
+    this.enclave = enclave;
+  }
+
+  @Override
+  public void handle(RoutingContext routingContext) {
+
+    byte[] request = routingContext.getBody().getBytes();
+    FindPrivacyGroupRequest findPrivacyGroupRequest =
+        Serializer.deserialize(JSON, FindPrivacyGroupRequest.class, request);
+
+    String[] addresses = findPrivacyGroupRequest.addresses();
+    Box.PublicKey[] toKeys = Arrays.stream(addresses).map(enclave::readKey).toArray(Box.PublicKey[]::new);
+
+    QueryPrivacyGroupPayload queryPrivacyGroupPayload =
+        new QueryPrivacyGroupPayload(findPrivacyGroupRequest.addresses(), null);
+    String key = queryPrivacyGroupStorage.generateDigest(queryPrivacyGroupPayload);
+    encodeBytes(enclave.generatePrivacyGroupId(toKeys, new byte[0], PrivacyGroupPayload.Type.LEGACY));
+
+
+    queryPrivacyGroupStorage.get(key).thenAccept((result) -> {
+      if (result.isPresent()) {
+        final Buffer responseData = Buffer.buffer(
+            Serializer.serialize(JSON, Collections.singletonMap("privacyGroupIds", result.get().privacyGroupId())));
+        routingContext.response().end(responseData);
+      } else {
+        routingContext.fail(new OrionException(OrionErrorCode.ENCLAVE_PRIVACY_GROUP_MISSING));
+      }
+    });
+  }
+
+}

--- a/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.handler.privacy;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FindPrivacyGroupRequest implements Serializable {
+
+  private final String[] addresses;
+
+  @JsonCreator
+  public FindPrivacyGroupRequest(@JsonProperty("addresses") String[] addresses) {
+    this.addresses = addresses;
+  }
+
+  @JsonProperty("addresses")
+  public String[] addresses() {
+    return addresses;
+  }
+
+}

--- a/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupResponse.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupResponse.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.handler.privacy;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FindPrivacyGroupResponse implements Serializable {
+
+  private String privacyGroupId;
+  private String name;
+  private String description;
+  private String[] members;
+
+  @JsonCreator
+  public FindPrivacyGroupResponse(
+      @JsonProperty("privacyGroupId") String privacyGroupId,
+      @JsonProperty("name") String name,
+      @JsonProperty("description") String description,
+      @JsonProperty("members") String[] members) {
+    this.privacyGroupId = privacyGroupId;
+    this.name = name;
+    this.description = description;
+    this.members = members;
+  }
+
+  @JsonProperty("privacyGroupId")
+  public String privacyGroupId() {
+    return privacyGroupId;
+  }
+
+  @JsonProperty("name")
+  public String name() {
+    return name;
+  }
+
+  @JsonProperty("description")
+  public String description() {
+    return description;
+  }
+
+  @JsonProperty("members")
+  public String[] members() {
+    return members;
+  }
+
+  public FindPrivacyGroupResponse() {}
+}

--- a/src/main/java/net/consensys/orion/http/handler/push/PushPrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/push/PushPrivacyGroupHandler.java
@@ -43,6 +43,9 @@ public class PushPrivacyGroupHandler implements Handler<RoutingContext> {
 
     storage.put(pushRequest).thenAccept((digest) -> {
       QueryPrivacyGroupPayload queryPrivacyGroupPayload = new QueryPrivacyGroupPayload(pushRequest.addresses(), null);
+      if (pushRequest.state().equals(PrivacyGroupPayload.State.DELETED)) {
+        queryPrivacyGroupPayload.setToDelete(true);
+      }
       queryPrivacyGroupPayload.setPrivacyGroupToAppend(storage.generateDigest(pushRequest));
       String key = queryPrivacyGroupStorage.generateDigest(queryPrivacyGroupPayload);
       queryPrivacyGroupStorage.update(key, queryPrivacyGroupPayload).thenApply((res) -> {

--- a/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendHandler.java
@@ -126,7 +126,8 @@ public class SendHandler implements Handler<RoutingContext> {
           send(routingContext, sendRequest, fromKey, toKeys, privacyGroupPayload);
           return result;
         }).exceptionally(e -> {
-          handleFailure(routingContext, e);
+          routingContext
+              .fail(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_STORE_PRIVACY_GROUP, "privacy group not stored"));
           return null;
         });
       }).exceptionally(e -> {

--- a/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/send/SendRequest.java
@@ -85,7 +85,7 @@ public class SendRequest implements Serializable {
   @JsonIgnore
   public boolean isValid() {
     return ((to != null && to.length > 0 && Arrays.stream(to).noneMatch(Strings::isNullOrEmpty))
-        || privacyGroupId != null)
+        || (privacyGroupId != null && privacyGroupId.length() > 0))
         && rawPayload != null
         && rawPayload.length > 0
         && (from == null || from.length() > 0);

--- a/src/main/java/net/consensys/orion/storage/EncryptedPayloadStorage.java
+++ b/src/main/java/net/consensys/orion/storage/EncryptedPayloadStorage.java
@@ -19,6 +19,8 @@ import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.concurrent.AsyncResult;
 import net.consensys.cava.kv.KeyValueStore;
 import net.consensys.orion.enclave.EncryptedPayload;
+import net.consensys.orion.exception.OrionErrorCode;
+import net.consensys.orion.exception.OrionException;
 import net.consensys.orion.http.server.HttpContentType;
 import net.consensys.orion.utils.Serializer;
 
@@ -54,5 +56,10 @@ public class EncryptedPayloadStorage implements Storage<EncryptedPayload> {
     return store.getAsync(keyBytes).thenApply(
         maybeBytes -> Optional.ofNullable(maybeBytes).map(
             bytes -> Serializer.deserialize(HttpContentType.CBOR, EncryptedPayload.class, bytes.toArrayUnsafe())));
+  }
+
+  @Override
+  public AsyncResult<Optional<EncryptedPayload>> update(String key, EncryptedPayload data) {
+    throw new OrionException(OrionErrorCode.METHOD_UNIMPLEMENTED);
   }
 }

--- a/src/main/java/net/consensys/orion/storage/OrionSQLKeyValueStore.java
+++ b/src/main/java/net/consensys/orion/storage/OrionSQLKeyValueStore.java
@@ -110,11 +110,11 @@ public class OrionSQLKeyValueStore implements KeyValueStore {
       if (successful) {
         return AsyncCompletion.completed();
       } else {
-        return AsyncCompletion.exceptional(new OrionException(OrionErrorCode.ENCLAVE_NO_MATCHING_PRIVATE_KEY));
+        return AsyncCompletion.exceptional(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_STORE_PRIVACY_GROUP));
       }
     } catch (InterruptedException | ExecutionException e) {
       e.printStackTrace();
-      return AsyncCompletion.exceptional(new OrionException(OrionErrorCode.ENCLAVE_NO_MATCHING_PRIVATE_KEY));
+      return AsyncCompletion.exceptional(new OrionException(OrionErrorCode.ENCLAVE_UNABLE_STORE_PRIVACY_GROUP));
     }
   }
 

--- a/src/main/java/net/consensys/orion/storage/OrionSQLKeyValueStore.java
+++ b/src/main/java/net/consensys/orion/storage/OrionSQLKeyValueStore.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.storage;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.concurrent.AsyncCompletion;
+import net.consensys.cava.concurrent.AsyncResult;
+import net.consensys.cava.kv.KeyValueStore;
+import net.consensys.cava.kv.SQLKeyValueStore;
+import net.consensys.orion.exception.OrionErrorCode;
+import net.consensys.orion.exception.OrionException;
+
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import com.jolbox.bonecp.BoneCP;
+import com.jolbox.bonecp.BoneCPConfig;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import kotlinx.coroutines.CoroutineDispatcher;
+import kotlinx.coroutines.Dispatchers;
+
+public class OrionSQLKeyValueStore implements KeyValueStore {
+  private SQLKeyValueStore delegate = null;
+
+  private final String jdbcUrl;
+  private final String tableName;
+  private final String keyColumn;
+  private final String valueColumn;
+
+  BoneCP connectionPool;
+  private final CoroutineDispatcher dispatcher = Dispatchers.getIO();
+
+  public OrionSQLKeyValueStore(String jdbcUrl, String tableName, String keyColumn, String valueColumn)
+      throws SQLException, IOException {
+    this.jdbcUrl = jdbcUrl;
+    this.tableName = tableName;
+    this.keyColumn = keyColumn;
+    this.valueColumn = valueColumn;
+    this.delegate = new SQLKeyValueStore(jdbcUrl, tableName, keyColumn, valueColumn, dispatcher);
+    setBoneCPConfig();
+  }
+
+  public OrionSQLKeyValueStore(String jdbcUrl) throws SQLException, IOException {
+    this(jdbcUrl, "store", "key", "value");
+  }
+
+  @Override
+  public AsyncResult<Bytes> getAsync(Bytes key) {
+    return delegate.getAsync(key);
+  }
+
+  @Override
+  public AsyncResult<Bytes> getAsync(CoroutineDispatcher dispatcher, Bytes key) {
+    return delegate.getAsync(dispatcher, key);
+  }
+
+  @Override
+  public AsyncCompletion putAsync(Bytes key, Bytes value) {
+    return put(key, value, null);
+  }
+
+  @Override
+  public AsyncCompletion putAsync(CoroutineDispatcher dispatcher, Bytes key, Bytes value) {
+    return delegate.putAsync(dispatcher, key, value);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public Bytes get(Bytes key, Continuation<? super Bytes> continuation) {
+    return (Bytes) delegate.get(key, continuation);
+  }
+
+  @Override
+  public AsyncCompletion put(Bytes key, Bytes value, Continuation<? super Unit> continuation) {
+
+    CompletableFuture<Boolean> cfs = new CompletableFuture<>();
+    PreparedStatement preparedStatement;
+    try {
+      preparedStatement = connectionPool.getConnection().prepareStatement(
+          String.format("MERGE INTO %s(%s,%s) VALUES(?,?)", tableName, keyColumn, valueColumn));
+      preparedStatement.setBytes(1, key.toArrayUnsafe());
+      preparedStatement.setBytes(2, value.toArrayUnsafe());
+      preparedStatement.execute();
+      cfs.complete(true);
+    } catch (SQLException e) {
+      e.printStackTrace();
+      cfs.completeExceptionally(e);
+    }
+
+    try {
+      Boolean successful = cfs.get();
+      if (successful) {
+        return AsyncCompletion.completed();
+      } else {
+        return AsyncCompletion.exceptional(new OrionException(OrionErrorCode.ENCLAVE_NO_MATCHING_PRIVATE_KEY));
+      }
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+      return AsyncCompletion.exceptional(new OrionException(OrionErrorCode.ENCLAVE_NO_MATCHING_PRIVATE_KEY));
+    }
+  }
+
+  private void setBoneCPConfig() throws SQLException {
+    BoneCPConfig boneCPConfig = new BoneCPConfig();
+    boneCPConfig.setJdbcUrl(jdbcUrl);
+    connectionPool = new BoneCP(boneCPConfig);
+  }
+
+}

--- a/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
+++ b/src/main/java/net/consensys/orion/storage/PrivacyGroupStorage.java
@@ -21,6 +21,8 @@ import net.consensys.cava.crypto.sodium.Box;
 import net.consensys.cava.kv.KeyValueStore;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.PrivacyGroupPayload;
+import net.consensys.orion.exception.OrionErrorCode;
+import net.consensys.orion.exception.OrionException;
 import net.consensys.orion.http.server.HttpContentType;
 import net.consensys.orion.utils.Serializer;
 
@@ -59,5 +61,10 @@ public class PrivacyGroupStorage implements Storage<PrivacyGroupPayload> {
     return store.getAsync(keyBytes).thenApply(
         maybeBytes -> Optional.ofNullable(maybeBytes).map(
             bytes -> Serializer.deserialize(HttpContentType.CBOR, PrivacyGroupPayload.class, bytes.toArrayUnsafe())));
+  }
+
+  @Override
+  public AsyncResult<Optional<PrivacyGroupPayload>> update(String key, PrivacyGroupPayload data) {
+    throw new OrionException(OrionErrorCode.METHOD_UNIMPLEMENTED);
   }
 }

--- a/src/main/java/net/consensys/orion/storage/QueryPrivacyGroupStorage.java
+++ b/src/main/java/net/consensys/orion/storage/QueryPrivacyGroupStorage.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.storage;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.consensys.cava.io.Base64.encodeBytes;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.concurrent.AsyncResult;
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.cava.kv.KeyValueStore;
+import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
+import net.consensys.orion.enclave.QueryPrivacyGroupPayload;
+import net.consensys.orion.http.server.HttpContentType;
+import net.consensys.orion.utils.Serializer;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class QueryPrivacyGroupStorage implements Storage<QueryPrivacyGroupPayload> {
+
+  private final KeyValueStore store;
+  private final Enclave enclave;
+  public byte[] bytes = new byte[20];
+
+  public QueryPrivacyGroupStorage(KeyValueStore store, Enclave enclave) {
+    this.store = store;
+    this.enclave = enclave;
+    SecureRandom random = new SecureRandom();
+    random.nextBytes(bytes);
+  }
+
+  @Override
+  public AsyncResult<String> put(QueryPrivacyGroupPayload data) {
+    String key = generateDigest(data);
+    Bytes keyBytes = Bytes.wrap(key.getBytes(UTF_8));
+    Bytes dataBytes = Bytes.wrap(Serializer.serialize(HttpContentType.CBOR, data));
+    return store.putAsync(keyBytes, dataBytes).thenSupply(() -> key);
+  }
+
+  @Override
+  public String generateDigest(QueryPrivacyGroupPayload data) {
+    Box.PublicKey[] publicKeys = Arrays.stream(data.addresses()).map(enclave::readKey).toArray(Box.PublicKey[]::new);
+    return encodeBytes(enclave.generatePrivacyGroupId(publicKeys, bytes, PrivacyGroupPayload.Type.PANTHEON));
+  }
+
+  @Override
+  public AsyncResult<Optional<QueryPrivacyGroupPayload>> get(String key) {
+    Bytes keyBytes = Bytes.wrap(key.getBytes(UTF_8));
+    return store.getAsync(keyBytes).thenApply(
+        maybeBytes -> Optional.ofNullable(maybeBytes).map(
+            bytes -> Serializer
+                .deserialize(HttpContentType.CBOR, QueryPrivacyGroupPayload.class, bytes.toArrayUnsafe())));
+  }
+
+  @Override
+  public AsyncResult<Optional<QueryPrivacyGroupPayload>> update(String key, QueryPrivacyGroupPayload data) {
+    return get(key).thenApply((result) -> {
+      List<String> listPrivacyGroupIds;
+      QueryPrivacyGroupPayload queryPrivacyGroupPayload;
+      if (result.isPresent()) {
+        if (data.isToDelete()) {
+          result.get().privacyGroupId().remove(data.privacyGroupToAppend());
+        } else {
+          result.get().privacyGroupId().add(data.privacyGroupToAppend());
+        }
+        listPrivacyGroupIds = result.get().privacyGroupId();
+        queryPrivacyGroupPayload = new QueryPrivacyGroupPayload(result.get().addresses(), listPrivacyGroupIds);
+      } else {
+        listPrivacyGroupIds = Collections.singletonList(data.privacyGroupToAppend());
+        queryPrivacyGroupPayload = new QueryPrivacyGroupPayload(data.addresses(), listPrivacyGroupIds);
+      }
+
+      put(queryPrivacyGroupPayload);
+      return Optional.of(queryPrivacyGroupPayload);
+    });
+  }
+}

--- a/src/main/java/net/consensys/orion/storage/Storage.java
+++ b/src/main/java/net/consensys/orion/storage/Storage.java
@@ -41,4 +41,13 @@ public interface Storage<T> {
    * @return The retrieved data.
    */
   AsyncResult<Optional<T>> get(String key);
+
+  /**
+   * Updates the data in the store.
+   *
+   * @param key should be base64 encoded UTF-8 string
+   * @param data the data to update key with
+   * @return The updated data.
+   */
+  AsyncResult<Optional<T>> update(String key, T data);
 }

--- a/src/test/java/net/consensys/orion/helpers/StubEnclave.java
+++ b/src/test/java/net/consensys/orion/helpers/StubEnclave.java
@@ -115,6 +115,10 @@ public class StubEnclave implements Enclave {
       outputStream.write(i);
     }
 
-    return outputStream.toByteArray();
+    if (type.equals(PrivacyGroupPayload.Type.PANTHEON)) {
+      return seed;
+    } else {
+      return outputStream.toByteArray();
+    }
   }
 }

--- a/src/test/java/net/consensys/orion/http/handler/FindPrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/FindPrivacyGroupHandlerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.handler;
+
+import static net.consensys.cava.io.Base64.encodeBytes;
+import static net.consensys.orion.http.server.HttpContentType.JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
+import net.consensys.orion.enclave.sodium.MemoryKeyStore;
+import net.consensys.orion.enclave.sodium.SodiumEnclave;
+import net.consensys.orion.helpers.FakePeer;
+import net.consensys.orion.http.handler.privacy.DeletePrivacyGroupRequest;
+import net.consensys.orion.http.handler.privacy.FindPrivacyGroupRequest;
+import net.consensys.orion.http.handler.privacy.PrivacyGroup;
+import net.consensys.orion.http.handler.privacy.PrivacyGroupRequest;
+import net.consensys.orion.utils.Serializer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FindPrivacyGroupHandlerTest extends HandlerTest {
+  private MemoryKeyStore memoryKeyStore;
+  private String privacyGroupId;
+  private FakePeer fakePeer;
+  private Box.PublicKey senderKey;
+  private String[] toEncrypt;
+
+  @Override
+  protected Enclave buildEnclave(Path tempDir) {
+    memoryKeyStore = new MemoryKeyStore();
+    Box.PublicKey defaultNodeKey = memoryKeyStore.generateKeyPair();
+    memoryKeyStore.addNodeKey(defaultNodeKey);
+    return new SodiumEnclave(memoryKeyStore);
+  }
+
+  @BeforeEach
+  void setup() throws IOException, InterruptedException {
+    senderKey = memoryKeyStore.generateKeyPair();
+    Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
+
+    toEncrypt = new String[] {encodeBytes(senderKey.bytesArray()), encodeBytes(recipientKey.bytesArray())};
+    PrivacyGroupRequest privacyGroupRequestExpected =
+        buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), "test", "desc");
+    Request request = buildPrivateAPIRequest("/privacyGroupId", JSON, privacyGroupRequestExpected);
+
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        new Box.PublicKey[] {senderKey, recipientKey},
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
+
+    // create fake peer
+    fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
+    networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
+
+    // execute request
+    Response resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    RecordedRequest recordedRequest = fakePeer.server.takeRequest();
+    assertEquals("/pushPrivacyGroup", recordedRequest.getPath());
+    assertEquals("POST", recordedRequest.getMethod());
+
+    PrivacyGroup privacyGroup = Serializer.deserialize(JSON, PrivacyGroup.class, resp.body().bytes());
+    privacyGroupId = privacyGroup.getPrivacyGroupId();
+  }
+
+  @Test
+  void findPrivacyGroupIdAfterCreation() throws Exception {
+    FindPrivacyGroupRequest findPrivacyGroupRequest = new FindPrivacyGroupRequest(toEncrypt);
+    Request request = buildPrivateAPIRequest("/findPrivacyGroupId", JSON, findPrivacyGroupRequest);
+
+    Response resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    TestList privacyGroupList = Serializer.deserialize(JSON, TestList.class, resp.body().bytes());
+    assertEquals(privacyGroupList.privacyGroupIds().size(), 1);
+    assertEquals(privacyGroupList.privacyGroupIds().get(0), privacyGroupId);
+
+  }
+
+  @Test
+  void findPrivacyAfterDelete() throws IOException {
+    // find the created privacy group
+    FindPrivacyGroupRequest findPrivacyGroupRequest = new FindPrivacyGroupRequest(toEncrypt);
+    Request request = buildPrivateAPIRequest("/findPrivacyGroupId", JSON, findPrivacyGroupRequest);
+
+    Response resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    TestList privacyGroupList = Serializer.deserialize(JSON, TestList.class, resp.body().bytes());
+    assertEquals(privacyGroupList.privacyGroupIds().size(), 1);
+    assertEquals(privacyGroupList.privacyGroupIds().get(0), privacyGroupId);
+
+    //delete the privacy group
+    DeletePrivacyGroupRequest deletePrivacyGroupRequest =
+        new DeletePrivacyGroupRequest(privacyGroupId, encodeBytes(senderKey.bytesArray()));
+
+    request = buildPrivateAPIRequest("/deletePrivacyGroupId", JSON, deletePrivacyGroupRequest);
+
+    fakePeer.addResponse(new MockResponse().setBody(privacyGroupId));
+    // execute request
+    resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    // find the same privacy group again
+    findPrivacyGroupRequest = new FindPrivacyGroupRequest(toEncrypt);
+    request = buildPrivateAPIRequest("/findPrivacyGroupId", JSON, findPrivacyGroupRequest);
+
+    resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    privacyGroupList = Serializer.deserialize(JSON, TestList.class, resp.body().bytes());
+    assertEquals(privacyGroupList.privacyGroupIds().size(), 0);
+  }
+
+  PrivacyGroupRequest buildPrivacyGroupRequest(String[] addresses, String from, String name, String description) {
+    PrivacyGroupRequest privacyGroupRequest = new PrivacyGroupRequest(addresses, from, name, description);
+    // create a random seed
+    SecureRandom random = new SecureRandom();
+    byte[] bytes = new byte[20];
+    random.nextBytes(bytes);
+    privacyGroupRequest.setSeed(bytes);
+
+    return privacyGroupRequest;
+  }
+}
+
+
+class TestList {
+  public List<String> privacyGroupIds() {
+    return privacyGroupIds;
+  }
+
+  public void setPrivacyGroupIds(List<String> list) {
+    this.privacyGroupIds = list;
+  }
+
+  @JsonProperty("privacyGroupIds")
+  public List<String> privacyGroupIds;
+
+  TestList() {}
+}

--- a/src/test/java/net/consensys/orion/http/handler/HandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/HandlerTest.java
@@ -25,12 +25,14 @@ import net.consensys.orion.config.Config;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.EncryptedPayload;
 import net.consensys.orion.enclave.PrivacyGroupPayload;
+import net.consensys.orion.enclave.QueryPrivacyGroupPayload;
 import net.consensys.orion.exception.OrionErrorCode;
 import net.consensys.orion.helpers.StubEnclave;
 import net.consensys.orion.http.server.HttpContentType;
 import net.consensys.orion.network.ConcurrentNetworkNodes;
 import net.consensys.orion.storage.EncryptedPayloadStorage;
 import net.consensys.orion.storage.PrivacyGroupStorage;
+import net.consensys.orion.storage.QueryPrivacyGroupStorage;
 import net.consensys.orion.storage.Sha512_256StorageKeyBuilder;
 import net.consensys.orion.storage.Storage;
 import net.consensys.orion.storage.StorageKeyBuilder;
@@ -75,6 +77,7 @@ abstract class HandlerTest {
 
   private KeyValueStore storage;
   protected Storage<EncryptedPayload> payloadStorage;
+  protected Storage<QueryPrivacyGroupPayload> queryPrivacyGroupStorage;
   protected Storage<PrivacyGroupPayload> privacyGroupStorage;
 
   @BeforeEach
@@ -98,6 +101,7 @@ abstract class HandlerTest {
     vertx = Vertx.vertx();
     StorageKeyBuilder keyBuilder = new Sha512_256StorageKeyBuilder();
     payloadStorage = new EncryptedPayloadStorage(storage, keyBuilder);
+    queryPrivacyGroupStorage = new QueryPrivacyGroupStorage(storage, enclave);
     privacyGroupStorage = new PrivacyGroupStorage(storage, enclave);
     Router publicRouter = Router.router(vertx);
     Router privateRouter = Router.router(vertx);
@@ -107,6 +111,7 @@ abstract class HandlerTest {
         enclave,
         payloadStorage,
         privacyGroupStorage,
+        queryPrivacyGroupStorage,
         publicRouter,
         privateRouter,
         config);

--- a/src/test/java/net/consensys/orion/http/handler/SendHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/SendHandlerTest.java
@@ -476,7 +476,7 @@ class SendHandlerTest extends HandlerTest {
     Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
     Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
     byte[] privacyGroupId = enclave
-        .generatePrivacyGroupId(new Box.PublicKey[] {recipientKey, senderKey}, null, PrivacyGroupPayload.Type.LEGACY);
+        .generatePrivacyGroupId(new Box.PublicKey[] {recipientKey, senderKey}, null, PrivacyGroupPayload.Type.PANTHEON);
 
     // generate random byte content
     byte[] toEncrypt = new byte[342];

--- a/src/test/java/net/consensys/orion/storage/PrivacyGroupStorageTest.java
+++ b/src/test/java/net/consensys/orion/storage/PrivacyGroupStorageTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.storage;
+
+import static net.consensys.cava.io.Base64.encodeBytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.cava.junit.TempDirectory;
+import net.consensys.cava.junit.TempDirectoryExtension;
+import net.consensys.cava.kv.KeyValueStore;
+import net.consensys.orion.enclave.Enclave;
+import net.consensys.orion.enclave.PrivacyGroupPayload;
+import net.consensys.orion.enclave.sodium.MemoryKeyStore;
+import net.consensys.orion.enclave.sodium.SodiumEnclave;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.Security;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Optional;
+import java.util.Random;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TempDirectoryExtension.class)
+class PrivacyGroupStorageTest {
+  private MemoryKeyStore memoryKeyStore;
+  private KeyValueStore storage;
+
+  static {
+    Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  private Enclave enclave;
+  private Storage<PrivacyGroupPayload> payloadStorage;
+
+  @BeforeEach
+  void setup(@TempDirectory Path tempDir) throws IOException, SQLException {
+    memoryKeyStore = new MemoryKeyStore();
+    Box.PublicKey defaultNodeKey = memoryKeyStore.generateKeyPair();
+    memoryKeyStore.addNodeKey(defaultNodeKey);
+    enclave = new SodiumEnclave(memoryKeyStore);
+
+    String jdbcUrl = "jdbc:h2:" + tempDir.resolve("node2").toString();
+    try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+      Statement st = conn.createStatement();
+      st.executeUpdate("create table if not exists store(key binary, value binary, primary key(key))");
+    }
+    storage = new OrionSQLKeyValueStore(jdbcUrl);
+    payloadStorage = new PrivacyGroupStorage(storage, enclave);
+  }
+
+  @Test
+  void putAndGet() throws InterruptedException {
+    Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
+    Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
+
+    String[] toEncrypt = new String[] {encodeBytes(senderKey.bytesArray()), encodeBytes(recipientKey.bytesArray())};
+
+    // generate random byte content
+    byte[] seed = new byte[20];
+    new Random().nextBytes(seed);
+
+    PrivacyGroupPayload privacyGroupPayload1 = new PrivacyGroupPayload(
+        toEncrypt,
+        "name",
+        "des",
+        PrivacyGroupPayload.State.ACTIVE,
+        PrivacyGroupPayload.Type.PANTHEON,
+        seed);
+
+    String key1 = payloadStorage.put(privacyGroupPayload1).get();
+    Optional<PrivacyGroupPayload> optionalPrivacyGroupPayload = payloadStorage.get(key1).get();
+    assertNotNull(optionalPrivacyGroupPayload);
+    assertTrue(optionalPrivacyGroupPayload.isPresent());
+    assertEquals(optionalPrivacyGroupPayload.get().state(), PrivacyGroupPayload.State.ACTIVE);
+  }
+
+  @Test
+  void storeTwice() throws InterruptedException {
+    Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
+    Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
+
+    String[] toEncrypt = new String[] {encodeBytes(senderKey.bytesArray()), encodeBytes(recipientKey.bytesArray())};
+
+    // generate random byte content
+    byte[] seed = new byte[20];
+    new Random().nextBytes(seed);
+
+    PrivacyGroupPayload privacyGroupPayload1 = new PrivacyGroupPayload(
+        toEncrypt,
+        "name",
+        "des",
+        PrivacyGroupPayload.State.ACTIVE,
+        PrivacyGroupPayload.Type.PANTHEON,
+        seed);
+
+    String key1 = payloadStorage.put(privacyGroupPayload1).get();
+
+    PrivacyGroupPayload privacyGroupPayload2 = new PrivacyGroupPayload(
+        toEncrypt,
+        "name",
+        "des",
+        PrivacyGroupPayload.State.DELETED,
+        PrivacyGroupPayload.Type.PANTHEON,
+        seed);
+
+    String key2 = payloadStorage.put(privacyGroupPayload2).get();
+    assertEquals(key1, key2);
+  }
+}


### PR DESCRIPTION
`findPrivacyGroup` returns the list of all the details of the privacy groups the given addresses are a part of. 
