### PR TITLE
Change generatePrivacyGroupId to generate hash based on random seed

### DIFF
--- a/src/main/java/net/consensys/orion/enclave/sodium/SodiumEnclave.java
+++ b/src/main/java/net/consensys/orion/enclave/sodium/SodiumEnclave.java
@@ -88,16 +88,14 @@ public class SodiumEnclave implements Enclave {
         .map(Box.PublicKey::bytesArray)
         .collect(Collectors.toList());
 
+
+    if (seed != null && type.equals(PrivacyGroupPayload.Type.PANTHEON)) {
+      recipientsAndSenderList.add(seed);
+    }
+
     Bytes rlpEncoded = RLP.encodeList(listWriter -> recipientsAndSenderList.forEach(listWriter::writeByteArray));
 
-    byte[] groupId = Hash.keccak256(rlpEncoded).toArray();
-
-    // concatenate the PrivacyGroupId with a random seed
-    if (seed != null && type.equals(PrivacyGroupPayload.Type.PANTHEON)) {
-      return Bytes.concatenate(Bytes.wrap(groupId), Bytes.wrap(seed)).toArray();
-    } else {
-      return groupId;
-    }
+    return Hash.keccak256(rlpEncoded).toArray();
   }
 
   @Override


### PR DESCRIPTION
generatePrivacyGroupId previously appended a seed to a pre-generated hash rather than generating the hash based on the seed. This fixes that error.