### PR TITLE
Upgrade jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,9 +249,9 @@ dependencies {
 
   // serialization
   compile 'com.moandjiezana.toml:toml4j:0.7.2'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.8'
-  compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.8'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9.1'
+  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.9'
+  compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.9'
 
   // logging
   compile 'org.apache.logging.log4j:log4j-api:2.11.2'


### PR DESCRIPTION
Upgrade Jackson dependency, specifically to resolve a security alert in jackson-databind but may as well keep the rest up to date.