### PR TITLE
PAN-2933: Always return empty list when privacy group id doesn't exist

### DIFF
--- a/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/FindPrivacyGroupHandler.java
@@ -122,7 +122,8 @@ public class FindPrivacyGroupHandler implements Handler<RoutingContext> {
         });
 
       } else {
-        routingContext.fail(new OrionException(OrionErrorCode.ENCLAVE_PRIVACY_GROUP_MISSING));
+        final Buffer responseData = Buffer.buffer(Serializer.serialize(JSON, new ArrayList<>()));
+        routingContext.response().end(responseData);
       }
     });
   }

--- a/src/test/java/net/consensys/orion/http/handler/FindPrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/FindPrivacyGroupHandlerTest.java
@@ -91,6 +91,24 @@ public class FindPrivacyGroupHandlerTest extends HandlerTest {
   }
 
   @Test
+  void findPrivacyGroupIdBeforeCreationShouldReturnEmptyList() throws Exception {
+    Box.PublicKey newSender = memoryKeyStore.generateKeyPair();
+    Box.PublicKey newRecipient = memoryKeyStore.generateKeyPair();
+
+    String[] to = new String[] {encodeBytes(newSender.bytesArray()), encodeBytes(newRecipient.bytesArray())};
+
+    FindPrivacyGroupRequest findPrivacyGroupRequest = new FindPrivacyGroupRequest(to);
+    Request request = buildPrivateAPIRequest("/findPrivacyGroup", JSON, findPrivacyGroupRequest);
+
+    Response resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    PrivacyGroup[] privacyGroupList = Serializer.deserialize(JSON, PrivacyGroup[].class, resp.body().bytes());
+    assertEquals(privacyGroupList.length, 0);
+  }
+
+  @Test
   void findPrivacyGroupIdAfterCreation() throws Exception {
     FindPrivacyGroupRequest findPrivacyGroupRequest = new FindPrivacyGroupRequest(toEncrypt);
     Request request = buildPrivateAPIRequest("/findPrivacyGroup", JSON, findPrivacyGroupRequest);


### PR DESCRIPTION
**Problem**
When calling eea_findPrivacyGroup for the first time before any groups have been created, the API responses with {"message":"Error finding privacy group","code":-50100}

I would have expected an empty array to be returned if no groups could be found.

Interestingly, if you create a group, delete the group and then find a group again, eea_findPrivacyGroup returns the expected response of an empty array