### PR TITLE
[OR-290] Null checks name and description of privacy group, and associated test

### DIFF
--- a/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
+++ b/src/main/java/net/consensys/orion/exception/OrionErrorCode.java
@@ -56,7 +56,8 @@ public enum OrionErrorCode {
   ENCLAVE_PRIVACY_GROUP_MISSING("PrivacyGroupNotFound"),
   ENCLAVE_PRIVACY_QUERY_ERROR("PrivacyGroupQueryError"),
   METHOD_UNIMPLEMENTED("MethodUnimplemented"),
-  CREATE_GROUP_INCLUDE_SELF("CreatePrivacyGroupShouldIncludeSelf");
+  CREATE_GROUP_INCLUDE_SELF("CreatePrivacyGroupShouldIncludeSelf"),
+  CREATE_GROUP_INVALID_PARAMS("CreateGroupInvalidParams");
 
   private final String code;
 

--- a/src/main/java/net/consensys/orion/http/handler/privacy/CreatePrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/CreatePrivacyGroupHandler.java
@@ -76,7 +76,7 @@ public class CreatePrivacyGroupHandler implements Handler<RoutingContext> {
     byte[] request = routingContext.getBody().getBytes();
     PrivacyGroupRequest privacyGroupRequest = Serializer.deserialize(JSON, PrivacyGroupRequest.class, request);
 
-    if (privacyGroupRequest.name() == null || privacyGroupRequest.description() == null) {
+    if (privacyGroupRequest.name().isBlank() || privacyGroupRequest.description().isBlank()) {
       routingContext.fail(
           new OrionException(
               OrionErrorCode.CREATE_GROUP_INVALID_PARAMS,

--- a/src/main/java/net/consensys/orion/http/handler/privacy/CreatePrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/CreatePrivacyGroupHandler.java
@@ -76,6 +76,14 @@ public class CreatePrivacyGroupHandler implements Handler<RoutingContext> {
     byte[] request = routingContext.getBody().getBytes();
     PrivacyGroupRequest privacyGroupRequest = Serializer.deserialize(JSON, PrivacyGroupRequest.class, request);
 
+    if (privacyGroupRequest.name() == null || privacyGroupRequest.description() == null) {
+      routingContext.fail(
+          new OrionException(
+              OrionErrorCode.CREATE_GROUP_INVALID_PARAMS,
+              "neither the name nor the description may be null "));
+      return;
+    }
+
     if (!Arrays.asList(privacyGroupRequest.addresses()).contains(privacyGroupRequest.from())) {
       routingContext.fail(
           new OrionException(OrionErrorCode.CREATE_GROUP_INCLUDE_SELF, "the list of addresses should include self "));

--- a/src/test/java/net/consensys/orion/http/handler/CreatePrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/CreatePrivacyGroupHandlerTest.java
@@ -80,6 +80,34 @@ public class CreatePrivacyGroupHandlerTest extends HandlerTest {
     assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload));
   }
 
+
+  @Test
+  void expectedPrivacyGroupError() throws Exception {
+    Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
+    Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
+
+    String[] toEncrypt = new String[] {encodeBytes(senderKey.bytesArray()), encodeBytes(recipientKey.bytesArray())};
+    Box.PublicKey[] addresses = Arrays.stream(toEncrypt).map(enclave::readKey).toArray(Box.PublicKey[]::new);
+
+    PrivacyGroupRequest privacyGroupRequestExpected =
+        buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), null, null);
+    Request request = buildPrivateAPIRequest("/createPrivacyGroup", JSON, privacyGroupRequestExpected);
+
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        addresses,
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
+
+    // create fake peer
+    FakePeer fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
+    networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
+
+    // execute request
+    Response resp = httpClient.newCall(request).execute();
+    assertEquals(500, resp.code());
+  }
+
+
   @Test
   void oddNumberOfRecipientsPrivacyGroupId() throws IOException {
     Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();


### PR DESCRIPTION
Issue: createPrivacyGroup should fail when required parameters `name` and `description` are not included.

This PR addresses the issue.