### PR TITLE
[PAN-2996] Remove unnecessary parameter when deleting privacy group

### DIFF
--- a/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupHandler.java
@@ -15,6 +15,7 @@ package net.consensys.orion.http.handler.privacy;
 import static net.consensys.orion.http.server.HttpContentType.JSON;
 
 import net.consensys.cava.crypto.sodium.Box;
+import net.consensys.cava.io.Base64;
 import net.consensys.orion.config.Config;
 import net.consensys.orion.enclave.Enclave;
 import net.consensys.orion.enclave.PrivacyGroupPayload;
@@ -86,9 +87,12 @@ public class DeletePrivacyGroupHandler implements Handler<RoutingContext> {
         // set state to deleted and propagate and store it
         privacyGroupPayload.setState(PrivacyGroupPayload.State.DELETED);
 
+        final List<String> nodeKeys =
+            Arrays.stream(enclave.nodeKeys()).map(key -> Base64.encodeBytes(key.bytesArray())).collect(
+                Collectors.toList());
         final List<Box.PublicKey> addressListToForward = Arrays
             .stream(privacyGroupPayload.addresses())
-            .filter(key -> !key.equals(privacyGroup.from())) // don't forward to self
+            .filter(nodeKeys::contains) // don't forward to self
             .distinct()
             .map(enclave::readKey)
             .collect(Collectors.toList());

--- a/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupRequest.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/DeletePrivacyGroupRequest.java
@@ -20,23 +20,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class DeletePrivacyGroupRequest implements Serializable {
 
   private final String privacyGroupId;
-  private final String from;
 
   @JsonCreator
-  public DeletePrivacyGroupRequest(
-      @JsonProperty("privacyGroupId") String privacyGroupId,
-      @JsonProperty("from") String from) {
+  public DeletePrivacyGroupRequest(@JsonProperty("privacyGroupId") String privacyGroupId) {
     this.privacyGroupId = privacyGroupId;
-    this.from = from;
   }
 
   @JsonProperty("privacyGroupId")
   public String privacyGroupId() {
     return privacyGroupId;
-  }
-
-  @JsonProperty("from")
-  public String from() {
-    return from;
   }
 }

--- a/src/test/java/net/consensys/orion/http/handler/DeletePrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/DeletePrivacyGroupHandlerTest.java
@@ -87,8 +87,7 @@ public class DeletePrivacyGroupHandlerTest extends HandlerTest {
   @Test
   void expectedDeletePrivacyGroupId() throws Exception {
 
-    DeletePrivacyGroupRequest deletePrivacyGroupRequest =
-        buildDeletePrivacyGroupRequest(privacyGroupId, encodeBytes(senderKey.bytesArray()));
+    DeletePrivacyGroupRequest deletePrivacyGroupRequest = buildDeletePrivacyGroupRequest(privacyGroupId);
 
     Request request = buildPrivateAPIRequest("/deletePrivacyGroup", JSON, deletePrivacyGroupRequest);
 
@@ -102,8 +101,7 @@ public class DeletePrivacyGroupHandlerTest extends HandlerTest {
   @Test
   void expectErrorDeletePrivacyGroupIdTwice() throws Exception {
 
-    DeletePrivacyGroupRequest deletePrivacyGroupRequest =
-        buildDeletePrivacyGroupRequest(privacyGroupId, encodeBytes(senderKey.bytesArray()));
+    DeletePrivacyGroupRequest deletePrivacyGroupRequest = buildDeletePrivacyGroupRequest(privacyGroupId);
 
     Request request = buildPrivateAPIRequest("/deletePrivacyGroup", JSON, deletePrivacyGroupRequest);
 
@@ -122,8 +120,7 @@ public class DeletePrivacyGroupHandlerTest extends HandlerTest {
   @Test
   void expectErrorDeleteIncorrectPrivacyGroupId() throws Exception {
 
-    DeletePrivacyGroupRequest deletePrivacyGroupRequest =
-        buildDeletePrivacyGroupRequest("test", encodeBytes(senderKey.bytesArray()));
+    DeletePrivacyGroupRequest deletePrivacyGroupRequest = buildDeletePrivacyGroupRequest("test");
 
     Request request = buildPrivateAPIRequest("/deletePrivacyGroup", JSON, deletePrivacyGroupRequest);
 
@@ -145,7 +142,7 @@ public class DeletePrivacyGroupHandlerTest extends HandlerTest {
     return privacyGroupRequest;
   }
 
-  DeletePrivacyGroupRequest buildDeletePrivacyGroupRequest(String key, String from) {
-    return new DeletePrivacyGroupRequest(key, from);
+  DeletePrivacyGroupRequest buildDeletePrivacyGroupRequest(String key) {
+    return new DeletePrivacyGroupRequest(key);
   }
 }

--- a/src/test/java/net/consensys/orion/http/handler/FindPrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/FindPrivacyGroupHandlerTest.java
@@ -144,8 +144,7 @@ public class FindPrivacyGroupHandlerTest extends HandlerTest {
     assertEquals(privacyGroupList[0].getDescription(), description);
 
     //delete the privacy group
-    DeletePrivacyGroupRequest deletePrivacyGroupRequest =
-        new DeletePrivacyGroupRequest(privacyGroupId, encodeBytes(senderKey.bytesArray()));
+    DeletePrivacyGroupRequest deletePrivacyGroupRequest = new DeletePrivacyGroupRequest(privacyGroupId);
 
     request = buildPrivateAPIRequest("/deletePrivacyGroup", JSON, deletePrivacyGroupRequest);
 


### PR DESCRIPTION
As a result of https://github.com/PegaSysEng/pantheon/pull/1777 mirroring this change in Orion