### PR TITLE
Release 1.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 plugins {
   id "com.diffplug.gradle.spotless" version "3.10.0"
   id "com.github.hierynomus.license" version "0.14.0"

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,6 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-
-import net.ltgt.gradle.errorprone.CheckSeverity
-
 plugins {
   id "com.diffplug.gradle.spotless" version "3.10.0"
   id "com.github.hierynomus.license" version "0.14.0"
@@ -29,7 +26,7 @@ apply plugin: 'maven-publish'
 apply from: "gradle/check-licenses.gradle"
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.3.1'
+version = '1.3.2'
 
 //////
 // Default tasks and build aliases

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'maven-publish'
 apply from: "gradle/check-licenses.gradle"
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.4.0-SNAPSHOT'
+version = '1.3.1'
 
 //////
 // Default tasks and build aliases

--- a/src/main/java/net/consensys/orion/http/handler/privacy/CreatePrivacyGroupHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/privacy/CreatePrivacyGroupHandler.java
@@ -75,14 +75,6 @@ public class CreatePrivacyGroupHandler implements Handler<RoutingContext> {
     final byte[] request = routingContext.getBody().getBytes();
     final PrivacyGroupRequest privacyGroupRequest = Serializer.deserialize(JSON, PrivacyGroupRequest.class, request);
 
-    if (privacyGroupRequest.name().isBlank() || privacyGroupRequest.description().isBlank()) {
-      routingContext.fail(
-          new OrionException(
-              OrionErrorCode.CREATE_GROUP_INVALID_PARAMS,
-              "neither the name nor the description may be null "));
-      return;
-    }
-
     if (!Arrays.asList(privacyGroupRequest.addresses()).contains(privacyGroupRequest.from())) {
       routingContext.fail(
           new OrionException(OrionErrorCode.CREATE_GROUP_INCLUDE_SELF, "the list of addresses should include self "));
@@ -102,8 +94,10 @@ public class CreatePrivacyGroupHandler implements Handler<RoutingContext> {
 
     final PrivacyGroupPayload privacyGroupPayload = new PrivacyGroupPayload(
         privacyGroupRequest.addresses(),
-        privacyGroupRequest.name(),
-        privacyGroupRequest.description(),
+        privacyGroupRequest.name() == null || privacyGroupRequest.name().isBlank() ? "Default Name"
+            : privacyGroupRequest.name(),
+        privacyGroupRequest.description() == null || privacyGroupRequest.description().isBlank() ? "Default Description"
+            : privacyGroupRequest.description(),
         PrivacyGroupPayload.State.ACTIVE,
         PrivacyGroupPayload.Type.PANTHEON,
         bytes);

--- a/src/test/java/net/consensys/orion/http/handler/CreatePrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/CreatePrivacyGroupHandlerTest.java
@@ -187,6 +187,37 @@ public class CreatePrivacyGroupHandlerTest extends HandlerTest {
     return privacyGroupRequest;
   }
 
+  @Test
+  void expectedPrivacyGroupIdWithoutOptionalParameters() throws Exception {
+    Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
+    Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
+
+    String[] toEncrypt = new String[] {encodeBytes(senderKey.bytesArray()), encodeBytes(recipientKey.bytesArray())};
+    Box.PublicKey[] addresses = Arrays.stream(toEncrypt).map(enclave::readKey).toArray(Box.PublicKey[]::new);
+
+    PrivacyGroupRequest privacyGroupRequestExpected =
+        buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), null, null);
+    Request request = buildPrivateAPIRequest("/createPrivacyGroup", JSON, privacyGroupRequestExpected);
+
+    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
+        addresses,
+        privacyGroupRequestExpected.getSeed().get(),
+        PrivacyGroupPayload.Type.PANTHEON);
+
+    // create fake peer
+    FakePeer fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
+    networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
+
+    // execute request
+    Response resp = httpClient.newCall(request).execute();
+
+    assertEquals(200, resp.code());
+
+    PrivacyGroup privacyGroup = Serializer.deserialize(JSON, PrivacyGroup.class, resp.body().bytes());
+
+    assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload));
+  }
+
   class FakePeer {
     final MockWebServer server;
     final Box.PublicKey publicKey;

--- a/src/test/java/net/consensys/orion/http/handler/CreatePrivacyGroupHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/CreatePrivacyGroupHandlerTest.java
@@ -80,34 +80,6 @@ public class CreatePrivacyGroupHandlerTest extends HandlerTest {
     assertEquals(privacyGroup.getPrivacyGroupId(), encodeBytes(privacyGroupPayload));
   }
 
-
-  @Test
-  void expectedPrivacyGroupError() throws Exception {
-    Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();
-    Box.PublicKey recipientKey = memoryKeyStore.generateKeyPair();
-
-    String[] toEncrypt = new String[] {encodeBytes(senderKey.bytesArray()), encodeBytes(recipientKey.bytesArray())};
-    Box.PublicKey[] addresses = Arrays.stream(toEncrypt).map(enclave::readKey).toArray(Box.PublicKey[]::new);
-
-    PrivacyGroupRequest privacyGroupRequestExpected =
-        buildPrivacyGroupRequest(toEncrypt, encodeBytes(senderKey.bytesArray()), null, null);
-    Request request = buildPrivateAPIRequest("/createPrivacyGroup", JSON, privacyGroupRequestExpected);
-
-    byte[] privacyGroupPayload = enclave.generatePrivacyGroupId(
-        addresses,
-        privacyGroupRequestExpected.getSeed().get(),
-        PrivacyGroupPayload.Type.PANTHEON);
-
-    // create fake peer
-    FakePeer fakePeer = new FakePeer(new MockResponse().setBody(encodeBytes(privacyGroupPayload)), recipientKey);
-    networkNodes.addNode(fakePeer.publicKey, fakePeer.getURL());
-
-    // execute request
-    Response resp = httpClient.newCall(request).execute();
-    assertEquals(500, resp.code());
-  }
-
-
   @Test
   void oddNumberOfRecipientsPrivacyGroupId() throws IOException {
     Box.PublicKey senderKey = memoryKeyStore.generateKeyPair();


### PR DESCRIPTION
* Added default name and description to CreatePrivacyGroup request
* Separated the initialization of the node and client http server from the discoverer. Now the discover is started after both http servers are up (so we can infer the nodeUrl when using dynamic ports in a reliable way)