### PR TITLE
OR-306: Fix PermTrustOption setup

### DIFF
--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -77,6 +77,7 @@ import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.LoggerHandler;
@@ -415,13 +416,18 @@ public class Orion {
       Path tlsServerKey = workDir.resolve(config.tlsServerKey());
       PemKeyCertOptions pemKeyCertOptions =
           new PemKeyCertOptions().setKeyPath(tlsServerKey.toString()).setCertPath(tlsServerCert.toString());
-      for (Path chainCert : config.tlsServerChain()) {
-        pemKeyCertOptions.addCertPath(chainCert.toAbsolutePath().toString());
-      }
 
       options.setSsl(true);
       options.setClientAuth(ClientAuth.REQUIRED);
       options.setPemKeyCertOptions(pemKeyCertOptions);
+
+      if (!config.tlsServerChain().isEmpty()) {
+        PemTrustOptions pemTrustOptions = new PemTrustOptions();
+        for (Path chainCert : config.tlsServerChain()) {
+          pemTrustOptions.addCertPath(chainCert.toAbsolutePath().toString());
+        }
+        options.setPemTrustOptions(pemTrustOptions);
+      }
 
       Path knownClientsFile = config.tlsKnownClients();
       String serverTrustMode = config.tlsServerTrust().toLowerCase();

--- a/src/main/java/net/consensys/orion/network/NodeHttpClientBuilder.java
+++ b/src/main/java/net/consensys/orion/network/NodeHttpClientBuilder.java
@@ -21,6 +21,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 
 public class NodeHttpClientBuilder {
 
@@ -37,12 +38,17 @@ public class NodeHttpClientBuilder {
 
       PemKeyCertOptions pemKeyCertOptions =
           new PemKeyCertOptions().setKeyPath(tlsClientKey.toString()).setCertPath(tlsClientCert.toString());
-      for (Path chainCert : config.tlsClientChain()) {
-        pemKeyCertOptions.addCertPath(chainCert.toAbsolutePath().toString());
-      }
 
       options.setSsl(true);
       options.setPemKeyCertOptions(pemKeyCertOptions);
+
+      if (!config.tlsClientChain().isEmpty()) {
+        PemTrustOptions pemTrustOptions = new PemTrustOptions();
+        for (Path chainCert : config.tlsClientChain()) {
+          pemTrustOptions.addCertPath(chainCert.toAbsolutePath().toString());
+        }
+        options.setPemTrustOptions(pemTrustOptions);
+      }
 
       Path knownServersFile = config.tlsKnownServers();
       String clientTrustMode = config.tlsClientTrust();


### PR DESCRIPTION
We were adding the CA certificates using the wrong Vertx config. We were adding the CA certificates as if they were a "regular" certificate, what was causing the complaint about invalid key.

I've found on the docs the right way to do it: https://vertx.io/docs/vertx-core/dataobjects.html#PemTrustOptions