### PR TITLE
[OR-319] Random prefix storage fix

### DIFF
--- a/src/acceptance-test/java/net/consensys/orion/acceptance/EthClientStub.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/EthClientStub.java
@@ -41,7 +41,7 @@ public class EthClientStub {
     this.clientPort = clientPort;
   }
 
-  boolean upCheck() {
+  public boolean upCheck() {
     final CompletableFuture<Integer> statusCodeFuture = new CompletableFuture<>();
     httpClient
         .get(clientPort, "localhost", "/upcheck")

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesPrivacyGroupsTest.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesPrivacyGroupsTest.java
@@ -267,6 +267,9 @@ class DualNodesPrivacyGroupsTest {
         Arrays.stream(deleteNodeSecondPrivacyGroups).map(PrivacyGroup::getPrivacyGroupId).collect(Collectors.toList());
     assertFalse(listSecond.contains(firstPrivacyGroupId));
     assertTrue(listSecond.contains(secondPrivacyGroupId));
+
+    // delete the second privacy group
+    deletePrivacyGroupTransaction(firstNode, secondPrivacyGroupId, PK_1_B_64);
   }
 
   @Test

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/QueryGroupRestartTest.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/QueryGroupRestartTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.acceptance.send.receive.privacyGroup;
+
+import static io.vertx.core.Vertx.vertx;
+import static net.consensys.cava.io.file.Files.copyResource;
+import static net.consensys.orion.acceptance.NodeUtils.createPrivacyGroupTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.findPrivacyGroupTransaction;
+import static net.consensys.orion.acceptance.NodeUtils.freePort;
+import static net.consensys.orion.acceptance.NodeUtils.joinPathsAsTomlListEntry;
+import static org.junit.Assert.assertEquals;
+
+import net.consensys.cava.junit.TempDirectory;
+import net.consensys.cava.junit.TempDirectoryExtension;
+import net.consensys.orion.acceptance.EthClientStub;
+import net.consensys.orion.acceptance.NodeUtils;
+import net.consensys.orion.cmd.Orion;
+import net.consensys.orion.config.Config;
+import net.consensys.orion.http.handler.privacy.PrivacyGroup;
+
+import java.nio.file.Path;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TempDirectoryExtension.class)
+public class QueryGroupRestartTest {
+  private static final String PK_1_B_64 = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
+  private static final String HOST_NAME = "127.0.0.1";
+
+  private static Config config;
+  private static int clientPort;
+
+  private Orion orionLauncher;
+  private Vertx vertx;
+  private HttpClient httpClient;
+
+  @BeforeAll
+  static void setUpSingleNode(@TempDirectory final Path tempDir) throws Exception {
+
+    final int nodePort = freePort();
+    clientPort = freePort();
+
+    final Path key1pub = copyResource("key1.pub", tempDir.resolve("key1.pub"));
+    final Path key1key = copyResource("key1.key", tempDir.resolve("key1.key"));
+
+    config = NodeUtils.nodeConfig(
+        tempDir,
+        nodePort,
+        HOST_NAME,
+        clientPort,
+        HOST_NAME,
+        "node1",
+        joinPathsAsTomlListEntry(key1pub),
+        joinPathsAsTomlListEntry(key1key),
+        "off",
+        "tofu",
+        "tofu",
+        "leveldb:database/node1");
+  }
+
+  @BeforeEach
+  void setUp() {
+    vertx = vertx();
+    orionLauncher = NodeUtils.startOrion(config);
+    httpClient = vertx.createHttpClient();
+  }
+
+  @AfterEach
+  void tearDown() {
+    orionLauncher.stop();
+    vertx.close();
+  }
+
+  @Test
+  void dualSendLegacyDoesNotDuplicateGroup() {
+    final EthClientStub ethClientStub = NodeUtils.client(clientPort, httpClient);
+
+    createPrivacyGroupTransaction(ethClientStub, new String[] {PK_1_B_64}, PK_1_B_64, "Test", "Test");
+
+    final PrivacyGroup[] privacyGroups = findPrivacyGroupTransaction(ethClientStub, new String[] {PK_1_B_64});
+
+    orionLauncher.stop();
+    vertx.close();
+
+    vertx = vertx();
+    orionLauncher = NodeUtils.startOrion(config);
+    httpClient = vertx.createHttpClient();
+
+    final EthClientStub ethClientStubAfterRestart = NodeUtils.client(clientPort, httpClient);
+
+    final PrivacyGroup[] privacyGroupsAfterRestart =
+        findPrivacyGroupTransaction(ethClientStubAfterRestart, new String[] {PK_1_B_64});
+
+    assertEquals(1, privacyGroups.length);
+    assertEquals(1, privacyGroupsAfterRestart.length);
+  }
+}

--- a/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/QueryGroupRestartTest.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/QueryGroupRestartTest.java
@@ -88,7 +88,7 @@ public class QueryGroupRestartTest {
   }
 
   @Test
-  void dualSendLegacyDoesNotDuplicateGroup() {
+  void nodeRestartDoesNotBreakFindPrivacyGroup() {
     final EthClientStub ethClientStub = NodeUtils.client(clientPort, httpClient);
 
     createPrivacyGroupTransaction(ethClientStub, new String[] {PK_1_B_64}, PK_1_B_64, "Test", "Test");

--- a/src/main/java/net/consensys/orion/storage/QueryPrivacyGroupStorage.java
+++ b/src/main/java/net/consensys/orion/storage/QueryPrivacyGroupStorage.java
@@ -25,23 +25,20 @@ import net.consensys.orion.enclave.QueryPrivacyGroupPayload;
 import net.consensys.orion.http.server.HttpContentType;
 import net.consensys.orion.utils.Serializer;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 public class QueryPrivacyGroupStorage implements Storage<QueryPrivacyGroupPayload> {
+  private static final byte[] BYTES = Bytes.fromHexString("5375ba871e5c3d0f1d055b5da0ac02ea035bed38").toArrayUnsafe();
 
   private final KeyValueStore store;
   private final Enclave enclave;
-  public final byte[] bytes = new byte[20];
 
   public QueryPrivacyGroupStorage(final KeyValueStore store, final Enclave enclave) {
     this.store = store;
     this.enclave = enclave;
-    final SecureRandom random = new SecureRandom();
-    random.nextBytes(bytes);
   }
 
   @Override
@@ -56,7 +53,7 @@ public class QueryPrivacyGroupStorage implements Storage<QueryPrivacyGroupPayloa
   public String generateDigest(final QueryPrivacyGroupPayload data) {
     final Box.PublicKey[] publicKeys =
         Arrays.stream(data.addresses()).map(enclave::readKey).toArray(Box.PublicKey[]::new);
-    return encodeBytes(enclave.generatePrivacyGroupId(publicKeys, bytes, PrivacyGroupPayload.Type.PANTHEON));
+    return encodeBytes(enclave.generatePrivacyGroupId(publicKeys, BYTES, PrivacyGroupPayload.Type.PANTHEON));
   }
 
   @Override


### PR DESCRIPTION
Don't create a random prefix for query storage on restart - use a fixed 20-byte seed instead.

Reason for this is you lose the ability to find privacy groups that were created before a restart of Orion.

[OR-319]

[OR-319]: https://pegasys1.atlassian.net/browse/OR-319