### PR TITLE
Updating dependencies (Snyk report)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,10 @@ dependencies {
 
   // storage
   compile 'org.fusesource.leveldbjni:leveldbjni-all'
-  compile 'org.mapdb:mapdb'
+  compile('org.mapdb:mapdb') {
+    exclude group: 'net.jpountz.lz4', module: 'lz4'
+  }
+  compile 'org.lz4:lz4-java'
   compile 'com.jolbox:bonecp'
   compile 'org.apache.openjpa:openjpa'
   compile 'org.postgresql:postgresql'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -68,6 +68,7 @@ dependencyManagement {
     dependency 'org.junit.jupiter:junit-jupiter-params:5.2.0'
 
     dependency 'org.mapdb:mapdb:3.0.7'
+    dependency 'org.lz4:lz4-java:1.6.0'
 
     dependency 'org.postgresql:postgresql:42.2.6'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -58,8 +58,8 @@ dependencyManagement {
 
     dependency 'org.awaitility:awaitility:3.1.0'
 
-    dependency 'org.bouncycastle:bcpkix-jdk15on:1.60'
-    dependency 'org.bouncycastle:bcprov-jdk15on:1.60'
+    dependency 'org.bouncycastle:bcpkix-jdk15on:1.64'
+    dependency 'org.bouncycastle:bcprov-jdk15on:1.64'
 
     dependency 'org.fusesource.leveldbjni:leveldbjni-all:1.8'
 


### PR DESCRIPTION
Two dependencies have been reported:
* MapDB
* Bouncycastle

Unfortunately, the MapDB version with the vulnerabilities is the latest one. This PR is only updating the Bouncycastle version.

https://app.snyk.io/org/pegasyseng/project/8d9836c0-882f-4b7b-a2b2-5ddbe6466dfe?utm_campaign=weekly_report&utm_source=Project