### PR TITLE
Removing log4j default jvm opts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -477,7 +477,6 @@ def getCheckedOutGitCommitHash() {
 // Runtime
 
 applicationDefaultJvmArgs = [
-  '-Dlog4j.configurationFile=log4j2.xml',
   "-Dvertx.disableFileCPResolving=true",
   "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory"
 ]


### PR DESCRIPTION
This property was overriding any other log setting, causing problems when trying to run this on Docker with a custom log4j.xml file.