### PR TITLE
Fix bad test expectation

### DIFF
--- a/src/test/java/net/consensys/orion/config/TomlConfigTest.java
+++ b/src/test/java/net/consensys/orion/config/TomlConfigTest.java
@@ -42,7 +42,7 @@ class TomlConfigTest {
     assertEquals(9001, testConf.nodePort());
     assertEquals("0.0.0.0", testConf.nodeNetworkInterface());
     assertEquals("memory", testConf.storage());
-    assertEquals("memory", testConf.knownNodesStorage());
+    assertEquals("mapdb:knownnodesdb", testConf.knownNodesStorage());
     assertEquals("off", testConf.tls());
     assertEquals("ca-or-tofu", testConf.tlsServerTrust());
     assertEquals("ca", testConf.tlsClientTrust());

--- a/src/test/resources/fullConfigTest.toml
+++ b/src/test/resources/fullConfigTest.toml
@@ -1,5 +1,5 @@
 # Test file with complete config settings (not defaults)
-knownnodesstorage = "memory"
+knownnodesstorage = "mapdb:knownnodesdb"
 nodeurl = "http://127.0.0.1:9001/"
 nodeport = 9001
 nodenetworkinterface = "0.0.0.0"


### PR DESCRIPTION
From Madeline: make sure to use a non-default value to test a custom value is properly set.