### PR TITLE
Fix backwards compat error

### DIFF
--- a/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesPrivacyGroupsTest.java
+++ b/src/acceptance-test/java/net/consensys/orion/acceptance/send/receive/privacyGroup/DualNodesPrivacyGroupsTest.java
@@ -148,7 +148,7 @@ class DualNodesPrivacyGroupsTest {
     final String firstNodeBaseUrl = NodeUtils.urlString("127.0.0.1", firstOrionLauncher.nodePort());
     final Request request = new Request.Builder().post(partyInfoBody).url(firstNodeBaseUrl + "/partyinfo").build();
     // first /partyinfo call may just get the one node, so wait until we get at least 2 nodes
-    await().atMost(10, TimeUnit.SECONDS).until(() -> getPartyInfoResponse(httpClient, request).nodeURIs().size() == 2);
+    await().atMost(15, TimeUnit.SECONDS).until(() -> getPartyInfoResponse(httpClient, request).nodeURIs().size() == 2);
 
   }
 

--- a/src/main/java/net/consensys/orion/network/NetworkNodes.java
+++ b/src/main/java/net/consensys/orion/network/NetworkNodes.java
@@ -30,7 +30,7 @@ public interface NetworkNodes {
   /**
    * @return URL of node
    */
-  @JsonProperty("uri")
+  @JsonProperty("url")
   URI uri();
 
   /**

--- a/src/main/java/net/consensys/orion/network/NodeHttpClientBuilder.java
+++ b/src/main/java/net/consensys/orion/network/NodeHttpClientBuilder.java
@@ -25,11 +25,14 @@ import org.apache.tuweni.net.tls.VertxTrustOptions;
 
 public class NodeHttpClientBuilder {
 
+  private static final int MAX_WAIT_QUEUE_SIZE = 32;
+
   private NodeHttpClientBuilder() {}
 
   public static HttpClient build(final Vertx vertx, final Config config, final int clientTimeoutMs) {
     final HttpClientOptions options =
-        new HttpClientOptions().setConnectTimeout(clientTimeoutMs).setIdleTimeout(clientTimeoutMs);
+        new HttpClientOptions().setConnectTimeout(clientTimeoutMs).setIdleTimeout(clientTimeoutMs).setMaxWaitQueueSize(
+            MAX_WAIT_QUEUE_SIZE);
 
     if ("strict".equals(config.tls())) {
       final Path workDir = config.workDir();

--- a/src/main/java/net/consensys/orion/network/ReadOnlyNetworkNodes.java
+++ b/src/main/java/net/consensys/orion/network/ReadOnlyNetworkNodes.java
@@ -35,7 +35,7 @@ public class ReadOnlyNetworkNodes implements NetworkNodes {
 
   @JsonCreator
   public ReadOnlyNetworkNodes(
-      @JsonProperty("uri") final URI uri,
+      @JsonProperty("url") final URI uri,
       @JsonProperty("nodeURLs") List<URI> nodeURIs,
       @JsonProperty("nodePKs") @JsonDeserialize(
           keyUsing = PublicKeyMapKeyDeserializer.class) final Map<Bytes, URI> nodePKs) {

--- a/src/test/java/net/consensys/orion/network/NetworkDiscoveryTest.java
+++ b/src/test/java/net/consensys/orion/network/NetworkDiscoveryTest.java
@@ -82,6 +82,30 @@ class NetworkDiscoveryTest {
   }
 
   @Test
+  void networkDiscoveryWithPeersOverTime() throws Exception {
+    Config config = Config.load("tls=\"off\"\nothernodes=[\"http://127.1.1.1:8080/\",\"http://192.168.1.2:8080/\"]");
+    // add peers
+    final FakePeer fakePeer =
+        new FakePeer(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE), Box.KeyPair.random().publicKey());
+    final FakePeer fakePeer2 =
+        new FakePeer(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE), Box.KeyPair.random().publicKey());
+    networkNodes.addNode(Collections.singletonMap(fakePeer.publicKey, fakePeer.getURI()).entrySet());
+    networkNodes.addNode(Collections.singletonMap(fakePeer2.publicKey, fakePeer2.getURI()).entrySet());
+    networkNodes.addNode(Collections.singletonMap(fakePeer2.publicKey, fakePeer.getURI()).entrySet());
+
+    // start network discovery
+    final NetworkDiscovery networkDiscovery = new NetworkDiscovery(networkNodes, config);
+    assertEquals(0, networkDiscovery.discoverers().size());
+    deployVerticle(networkDiscovery).join();
+    assertEquals(4, networkDiscovery.discoverers().size());
+    Thread.sleep(10 * (networkDiscovery.discoverers().values().iterator().next().currentRefreshDelay + 1000));
+    assertEquals(4, networkDiscovery.discoverers().size());
+    for (NetworkDiscovery.Discoverer discoverer : networkDiscovery.discoverers().values()) {
+      assertEquals(4, discoverer.attempts);
+    }
+  }
+
+  @Test
   void networkDiscoveryWithUnresponsivePeer() throws Exception {
     // add peers
     final FakePeer fakePeer =

--- a/src/test/java/net/consensys/orion/network/NetworkDiscoveryTest.java
+++ b/src/test/java/net/consensys/orion/network/NetworkDiscoveryTest.java
@@ -89,9 +89,9 @@ class NetworkDiscoveryTest {
         new FakePeer(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE), Box.KeyPair.random().publicKey());
     final FakePeer fakePeer2 =
         new FakePeer(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE), Box.KeyPair.random().publicKey());
-    networkNodes.addNode(Collections.singletonMap(fakePeer.publicKey, fakePeer.getURI()).entrySet());
-    networkNodes.addNode(Collections.singletonMap(fakePeer2.publicKey, fakePeer2.getURI()).entrySet());
-    networkNodes.addNode(Collections.singletonMap(fakePeer2.publicKey, fakePeer.getURI()).entrySet());
+    networkNodes.addNode(Collections.singletonMap(fakePeer.publicKey.bytes(), fakePeer.getURI()).entrySet());
+    networkNodes.addNode(Collections.singletonMap(fakePeer2.publicKey.bytes(), fakePeer2.getURI()).entrySet());
+    networkNodes.addNode(Collections.singletonMap(fakePeer2.publicKey.bytes(), fakePeer.getURI()).entrySet());
 
     // start network discovery
     final NetworkDiscovery networkDiscovery = new NetworkDiscovery(networkNodes, config);

--- a/src/test/java/net/consensys/orion/network/NetworkDiscoveryTest.java
+++ b/src/test/java/net/consensys/orion/network/NetworkDiscoveryTest.java
@@ -101,7 +101,7 @@ class NetworkDiscoveryTest {
     Thread.sleep(10 * (networkDiscovery.discoverers().values().iterator().next().currentRefreshDelay + 1000));
     assertEquals(4, networkDiscovery.discoverers().size());
     for (NetworkDiscovery.Discoverer discoverer : networkDiscovery.discoverers().values()) {
-      assertEquals(4, discoverer.attempts);
+      assertTrue(discoverer.attempts >= 3);
     }
   }
 


### PR DESCRIPTION
This PR does 2 things:
* It fixes a pretty gross backwards compatibility issue. uri != url.
* It ensures the timer doesn't get triggered again if the discoverer is already triggered to run. This might not be absolutely necessary, but it seems like clients have invalid behaviors.