### PR TITLE
[#358] Create self signed certificate for Client-To-Orion TLS strict mode

### DIFF
--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -398,12 +398,12 @@ public class Orion {
       final Path tlsServerKey = config.tlsServerKey();
       final Optional<URL> nodeUrl = config.nodeUrl();
 
-      createAndVerifyTLSCert(tlsServerKey, tlsServerCert, nodeUrl, "server");
+      createSelfSignedCertificateIfMissingAndValidate(tlsServerKey, tlsServerCert, nodeUrl, "server");
 
       // verify client TLS cert and key
       final Path tlsClientCert = config.tlsClientCert();
       final Path tlsClientKey = config.tlsClientKey();
-      createAndVerifyTLSCert(tlsClientKey, tlsClientCert, nodeUrl, "client");
+      createSelfSignedCertificateIfMissingAndValidate(tlsClientKey, tlsClientCert, nodeUrl, "client");
     }
 
     // verify Client-to-Orion server TLS certificate and key
@@ -412,7 +412,7 @@ public class Orion {
       final Path tlsServerKey = config.clientConnectionTlsServerKey();
       final Optional<URL> nodeUrl = config.nodeUrl();
 
-      createAndVerifyTLSCert(tlsServerKey, tlsServerCert, nodeUrl, "Client-to-Orion server");
+      createSelfSignedCertificateIfMissingAndValidate(tlsServerKey, tlsServerCert, nodeUrl, "Client-to-Orion server");
     }
 
     // Vertx routers
@@ -532,14 +532,14 @@ public class Orion {
     isRunning.set(true);
   }
 
-  private static void createAndVerifyTLSCert(
+  private static void createSelfSignedCertificateIfMissingAndValidate(
       final Path tlsKey,
       final Path tlsCert,
       final Optional<URL> nodeUrl,
-      final String label) {
+      final String label) throws OrionStartException {
     try {
       TLS.createSelfSignedCertificateIfMissing(tlsKey, tlsCert, nodeUrl);
-    } catch (final IOException e) {
+    } catch (final IOException | RuntimeException e) {
       throw new OrionStartException(
           "An error occurred while writing the " + label + " TLS certificate files: " + e.getMessage(),
           e);

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -543,9 +543,12 @@ public class Orion {
           "An error occurred while writing the " + label + " TLS certificate files: " + e.getMessage(),
           e);
     }
+
     if (!Files.exists(tlsCert)) {
       throw new OrionStartException("Missing " + label + " TLS certificate file \"" + tlsCert + "\"");
-    } else if (!Files.exists(tlsKey)) {
+    }
+
+    if (!Files.exists(tlsKey)) {
       throw new OrionStartException("Missing " + label + " TLS key file \"" + tlsKey + "\"");
     }
   }

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -406,6 +406,7 @@ public class Orion {
       createAndVerifyTLSCert(tlsClientKey, tlsClientCert, nodeUrl, "client");
     }
 
+    // verify Client-to-Orion server TLS certificate and key
     if ("strict".equals(config.clientConnectionTls())) {
       final Path tlsServerCert = config.clientConnectionTlsServerCert();
       final Path tlsServerKey = config.clientConnectionTlsServerKey();

--- a/src/test/java/net/consensys/orion/TestUtils.java
+++ b/src/test/java/net/consensys/orion/TestUtils.java
@@ -104,8 +104,15 @@ public class TestUtils {
   public static void writeClientConnectionServerCertToConfig(
       final Writer configWriter,
       final SelfSignedCertificate serverCert) throws IOException {
-    configWriter.write("clientconnectiontlsservercert=\"" + serverCert.certificatePath() + "\"\n");
-    configWriter.write("clientconnectiontlsserverkey=\"" + serverCert.privateKeyPath() + "\"\n");
+    writeClientConnectionServerCertToConfig(configWriter, serverCert.certificatePath(), serverCert.privateKeyPath());
+  }
+
+  public static void writeClientConnectionServerCertToConfig(
+      final Writer configWriter,
+      final String certificatePath,
+      final String privateKeyPath) throws IOException {
+    configWriter.write("clientconnectiontlsservercert=\"" + certificatePath + "\"\n");
+    configWriter.write("clientconnectiontlsserverkey=\"" + privateKeyPath + "\"\n");
   }
 
   public static int getFreePort() throws Exception {

--- a/src/test/java/net/consensys/orion/TestUtils.java
+++ b/src/test/java/net/consensys/orion/TestUtils.java
@@ -91,8 +91,15 @@ public class TestUtils {
 
   public static void writeServerCertToConfig(final Writer configWriter, final SelfSignedCertificate serverCert)
       throws IOException {
-    configWriter.write("tlsservercert=\"" + serverCert.certificatePath() + "\"\n");
-    configWriter.write("tlsserverkey=\"" + serverCert.privateKeyPath() + "\"\n");
+    writeServerCertToConfig(configWriter, serverCert.certificatePath(), serverCert.privateKeyPath());
+  }
+
+  public static void writeServerCertToConfig(
+      final Writer configWriter,
+      final String certificatePath,
+      final String privateKeyPath) throws IOException {
+    configWriter.write("tlsservercert=\"" + certificatePath + "\"\n");
+    configWriter.write("tlsserverkey=\"" + privateKeyPath + "\"\n");
   }
 
   public static void writeClientCertToConfig(final Writer configWriter, final SelfSignedCertificate serverCert)

--- a/src/test/java/net/consensys/orion/http/ClientOrionTlsCertificateAutoCreateTest.java
+++ b/src/test/java/net/consensys/orion/http/ClientOrionTlsCertificateAutoCreateTest.java
@@ -49,7 +49,6 @@ public class ClientOrionTlsCertificateAutoCreateTest {
 
   @BeforeEach
   void setUpConfig(@TempDirectory final Path tempDir) throws Exception {
-
     config = generateAndLoadConfiguration(tempDir, writer -> {
       writer.write("tlsservertrust='" + TRUST_MODE + "'\n");
       writer.write("clientconnectiontls='strict'\n");

--- a/src/test/java/net/consensys/orion/http/ClintOrionTlsCertificateCreateTest.java
+++ b/src/test/java/net/consensys/orion/http/ClintOrionTlsCertificateCreateTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http;
+
+import static io.vertx.core.Vertx.vertx;
+import static net.consensys.orion.TestUtils.generateAndLoadConfiguration;
+import static net.consensys.orion.TestUtils.writeClientConnectionServerCertToConfig;
+import static net.consensys.orion.TestUtils.writeServerCertToConfig;
+import static org.apache.tuweni.net.tls.TLS.readPemFile;
+
+import net.consensys.orion.cmd.Orion;
+import net.consensys.orion.config.Config;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.SelfSignedCertificate;
+import org.apache.tuweni.junit.TempDirectory;
+import org.apache.tuweni.junit.TempDirectoryExtension;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TempDirectoryExtension.class)
+public class ClintOrionTlsCertificateCreateTest {
+  private final static Vertx vertx = vertx();
+  private Orion orion;
+  private Config config;
+  private static final String TRUST_MODE = "tofu";
+  private final static String clientConnectionServerCert = "clientConnectionServerCert.pem";
+  private final static String clientConnectionServerKey = "clientConnectionServerKey.key";
+
+  @BeforeEach
+  void setUp(@TempDirectory final Path tempDir) throws Exception {
+    final SelfSignedCertificate serverCertificate = SelfSignedCertificate.create("localhost");
+
+    config = generateAndLoadConfiguration(tempDir, writer -> {
+      writer.write("tlsservertrust='" + TRUST_MODE + "'\n");
+      writer.write("clientconnectiontls='strict'\n");
+      writer.write("clientconnectiontlsservertrust='" + TRUST_MODE + "'\n");
+      writeServerCertToConfig(writer, serverCertificate);
+      writeClientConnectionServerCertToConfig(
+          writer,
+          tempDir.resolve(clientConnectionServerCert).toString(),
+          tempDir.resolve(clientConnectionServerKey).toString());
+    });
+
+    orion = new Orion(vertx);
+    orion.run(config, false);
+  }
+
+  @AfterEach
+  void tearDown() {
+    orion.stop();
+    vertx.close();
+  }
+
+  @Test
+  void clientConnectionTlsKeyCertificatePairCreated() {
+    Assertions
+        .assertThatCode(() -> new PKCS8EncodedKeySpec(readPemFile(config.clientConnectionTlsServerKey())))
+        .doesNotThrowAnyException();
+
+    Assertions
+        .assertThatCode(
+            () -> CertificateFactory.getInstance("X.509").generateCertificate(
+                new ByteArrayInputStream(Files.readAllBytes(config.clientConnectionTlsServerCert()))))
+        .doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
Orion [documentation](https://docs.orion.pegasys.tech/en/stable/Tutorials/TLS/#clientconnectiontlsservercert) mentions that (for Besu to Orion TLS connection) if server certificate and private key doesn't exist, a self-generate certificate will be created. This wasn't implemented in code.

Fix issue #358 

Signed-off-by: Usman Saleem <usman@usmans.info>