### PR TITLE
Reduce the logging noise when a payload is not found

### DIFF
--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -43,6 +43,7 @@ import net.consensys.orion.http.handler.send.SendHandler;
 import net.consensys.orion.http.handler.sendraw.SendRawHandler;
 import net.consensys.orion.http.handler.upcheck.UpcheckHandler;
 import net.consensys.orion.http.server.vertx.HttpErrorHandler;
+import net.consensys.orion.http.server.vertx.OrionLoggerHandler;
 import net.consensys.orion.network.NetworkDiscovery;
 import net.consensys.orion.network.PersistentNetworkNodes;
 import net.consensys.orion.payload.DistributePayloadManager;
@@ -157,7 +158,7 @@ public class Orion {
       final Router clientRouter,
       final Config config) {
 
-    final LoggerHandler loggerHandler = LoggerHandler.create();
+    final LoggerHandler loggerHandler = new OrionLoggerHandler();
 
     //Setup Orion node APIs
     nodeRouter

--- a/src/main/java/net/consensys/orion/http/server/vertx/OrionLoggerHandler.java
+++ b/src/main/java/net/consensys/orion/http/server/vertx/OrionLoggerHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.server.vertx;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.handler.LoggerFormat;
+
+public class OrionLoggerHandler extends io.vertx.ext.web.handler.impl.LoggerHandlerImpl {
+  private final Logger logger;
+
+  public OrionLoggerHandler() {
+    super(LoggerFormat.DEFAULT);
+    this.logger = LoggerFactory.getLogger(this.getClass());
+  }
+
+  @Override
+  protected void doLog(final int status, final String message) {
+    if (status >= 500) {
+      this.logger.error(message);
+    } else if (status >= 400) {
+      // To reduce noise 404s are only logged as debug. A 404 is returned for the common use case where Besu
+      // receives a private marker transaction for a privacy group that this Orion is not part of.
+      if (status == 404) {
+        this.logger.debug(message);
+      } else {
+        this.logger.warn(message);
+      }
+    } else {
+      this.logger.info(message);
+    }
+
+  }
+}


### PR DESCRIPTION
When Orion is asked for a payload (/receive) that it does not have it replies with a 404. This happens frequently, as Besu will ask for a payload for every private marker transaction (PMT) that it receives. If the PMT is not marking a private transaction for a privacy group that this particular Besu/Orion belong to the payload (which contains the private transaction) is not available in Orion and the 404 returned.
To reduce the logging noise 404s are now only logged on debug level.

Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>