### PR TITLE
Created http method to check Orion version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ mapdb
 db
 routerdb
 routerdb.wal.0
-version.txt
 
 
 ### Gradle ###

--- a/build.gradle
+++ b/build.gradle
@@ -329,13 +329,6 @@ group = 'net.consensys'
 jar {
   doFirst {
     delete fileTree(dir:'build/libs', include: '*.jar')
-    delete "$projectDir/src/main/resources/version.txt"
-    delete "$buildDir/resources/main/version.txt"
-
-    new File("$buildDir/resources/main/version.txt").text = """Application-name: $project.name
-Version: $project.version
-"""
-    new File("$buildDir/version").text = """$version"""
   }
   manifest {
     attributes('Implementation-Title': project.name,

--- a/src/main/java/net/consensys/orion/cmd/Orion.java
+++ b/src/main/java/net/consensys/orion/cmd/Orion.java
@@ -42,6 +42,7 @@ import net.consensys.orion.http.handler.receive.ReceiveHandler;
 import net.consensys.orion.http.handler.send.SendHandler;
 import net.consensys.orion.http.handler.sendraw.SendRawHandler;
 import net.consensys.orion.http.handler.upcheck.UpcheckHandler;
+import net.consensys.orion.http.handler.version.VersionHandler;
 import net.consensys.orion.http.server.vertx.HttpErrorHandler;
 import net.consensys.orion.http.server.vertx.OrionLoggerHandler;
 import net.consensys.orion.network.NetworkDiscovery;
@@ -130,7 +131,6 @@ public class Orion {
   private HttpServer clientHTTPServer;
 
   public static void main(final String[] args) {
-    log.info("starting orion");
     final Orion orion = new Orion();
     try {
       orion.run(System.out, System.err, args);
@@ -190,6 +190,7 @@ public class Orion {
     clientRouter.get("/upcheck").produces(TEXT.httpHeaderValue).handler(new UpcheckHandler());
     clientRouter.get("/peercount").produces(TEXT.httpHeaderValue).handler(
         new PeerCountHandler(() -> networkNodes.nodeURIs().size()));
+    clientRouter.get("/version").produces(TEXT.httpHeaderValue).handler(new VersionHandler());
 
     clientRouter.post("/send").produces(JSON.httpHeaderValue).consumes(JSON.httpHeaderValue).handler(
         new SendHandler(distributePayloadManager));
@@ -332,6 +333,8 @@ public class Orion {
     if (arguments.argumentExit()) {
       return;
     }
+
+    log.info("starting orion");
 
     // load config file
     final Config config = loadConfig(arguments.configFileName().map(Paths::get).orElse(null));

--- a/src/main/java/net/consensys/orion/cmd/OrionArguments.java
+++ b/src/main/java/net/consensys/orion/cmd/OrionArguments.java
@@ -12,17 +12,14 @@
  */
 package net.consensys.orion.cmd;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import net.consensys.orion.utils.OrionInfo;
+
 import java.io.PrintStream;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 class OrionArguments {
+
   private boolean argumentExit = false;
   private boolean clearKnownNodes = false;
 
@@ -93,16 +90,10 @@ class OrionArguments {
   }
 
   private void displayVersion(final PrintStream out, final PrintStream err) {
-    try (final InputStream versionAsStream = OrionArguments.class.getResourceAsStream("/version.txt")) {
-      if (versionAsStream == null) {
-        out.println("(development)");
-      } else {
-        final BufferedReader buffer = new BufferedReader(new InputStreamReader(versionAsStream, UTF_8));
-        final String contents = buffer.lines().collect(Collectors.joining("\n"));
-        out.println(contents);
-      }
-    } catch (final IOException e) {
-      err.println("Read of Version file failed " + e.getMessage());
+    try {
+      out.println(OrionInfo.version());
+    } catch (final Exception e) {
+      err.println("Error reading Orion version " + e.getMessage());
     }
   }
 

--- a/src/main/java/net/consensys/orion/http/handler/version/VersionHandler.java
+++ b/src/main/java/net/consensys/orion/http/handler/version/VersionHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.handler.version;
+
+import net.consensys.orion.utils.OrionInfo;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class VersionHandler implements Handler<RoutingContext> {
+
+  @Override
+  public void handle(final RoutingContext routingContext) {
+    try {
+      routingContext.response().setStatusCode(200).end(OrionInfo.version());
+    } catch (Exception e) {
+      routingContext.response().setStatusCode(500).end("Error retrieving Orion version");
+    }
+  }
+}

--- a/src/main/java/net/consensys/orion/utils/OrionInfo.java
+++ b/src/main/java/net/consensys/orion/utils/OrionInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.utils;
+
+public class OrionInfo {
+
+  private static final String CLIENT = "orion";
+  private static final String VERSION = OrionInfo.class.getPackage().getImplementationVersion();
+  private static final String OS = PlatformDetector.getOS();
+  private static final String VM = PlatformDetector.getVM();
+
+  private OrionInfo() {}
+
+  public static String version() {
+    return String.format("%s/%s/%s/%s", CLIENT, VERSION != null ? "v" + VERSION : "development", OS, VM);
+  }
+}

--- a/src/main/java/net/consensys/orion/utils/PlatformDetector.java
+++ b/src/main/java/net/consensys/orion/utils/PlatformDetector.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.utils;
+
+import java.util.Locale;
+
+/**
+ * Detects OS and VMs.
+ *
+ * <p>
+ * Derived from Detector.java https://github.com/trustin/os-maven-plugin/ version 59fd029 on 21 Apr 2018, Copyright 2014
+ * Trustin Heuiseung Lee.
+ */
+public class PlatformDetector {
+
+  private static String _os;
+  private static String _osType;
+  private static String _vm;
+
+  public static String getOSType() {
+    if (_osType == null) {
+      detect();
+    }
+    return _osType;
+  }
+
+  public static String getOS() {
+    if (_os == null) {
+      detect();
+    }
+    return _os;
+  }
+
+  public static String getVM() {
+    if (_vm == null) {
+      detect();
+    }
+    return _vm;
+  }
+
+  private static final String UNKNOWN = "unknown";
+
+  private static void detect() {
+    final String detectedOS = normalizeOS(normalize("os.name"));
+    final String detectedArch = normalizeArch(normalize("os.arch"));
+    final String detectedVM = normalizeVM(normalize("java.vendor"), normalize("java.vm.name"));
+    final String detectedJavaVersion = normalizeJavaVersion("java.specification.version");
+
+    _os = detectedOS + '-' + detectedArch;
+    _osType = detectedOS;
+    _vm = detectedVM + "-java-" + detectedJavaVersion;
+  }
+
+  private static String normalizeOS(final String osName) {
+    if (osName.startsWith("aix")) {
+      return "aix";
+    }
+    if (osName.startsWith("hpux")) {
+      return "hpux";
+    }
+    if (osName.startsWith("os400")) {
+      // Avoid the names such as os4000
+      if (osName.length() <= 5 || !Character.isDigit(osName.charAt(5))) {
+        return "os400";
+      }
+    }
+    if (osName.startsWith("linux")) {
+      return "linux";
+    }
+    if (osName.startsWith("macosx") || osName.startsWith("osx")) {
+      return "osx";
+    }
+    if (osName.startsWith("freebsd")) {
+      return "freebsd";
+    }
+    if (osName.startsWith("openbsd")) {
+      return "openbsd";
+    }
+    if (osName.startsWith("netbsd")) {
+      return "netbsd";
+    }
+    if (osName.startsWith("solaris") || osName.startsWith("sunos")) {
+      return "sunos";
+    }
+    if (osName.startsWith("windows")) {
+      return "windows";
+    }
+
+    return UNKNOWN;
+  }
+
+  private static String normalizeArch(final String osArch) {
+    if (osArch.matches("^(x8664|amd64|ia32e|em64t|x64)$")) {
+      return "x86_64";
+    }
+    if (osArch.matches("^(x8632|x86|i[3-6]86|ia32|x32)$")) {
+      return "x86_32";
+    }
+    if (osArch.matches("^(ia64w?|itanium64)$")) {
+      return "itanium_64";
+    }
+    if ("ia64n".equals(osArch)) {
+      return "itanium_32";
+    }
+    if (osArch.matches("^(sparc|sparc32)$")) {
+      return "sparc_32";
+    }
+    if (osArch.matches("^(sparcv9|sparc64)$")) {
+      return "sparc_64";
+    }
+    if (osArch.matches("^(arm|arm32)$")) {
+      return "arm_32";
+    }
+    if ("aarch64".equals(osArch)) {
+      return "aarch_64";
+    }
+    if (osArch.matches("^(mips|mips32)$")) {
+      return "mips_32";
+    }
+    if (osArch.matches("^(mipsel|mips32el)$")) {
+      return "mipsel_32";
+    }
+    if ("mips64".equals(osArch)) {
+      return "mips_64";
+    }
+    if ("mips64el".equals(osArch)) {
+      return "mipsel_64";
+    }
+    if (osArch.matches("^(ppc|ppc32)$")) {
+      return "ppc_32";
+    }
+    if (osArch.matches("^(ppcle|ppc32le)$")) {
+      return "ppcle_32";
+    }
+    if ("ppc64".equals(osArch)) {
+      return "ppc_64";
+    }
+    if ("ppc64le".equals(osArch)) {
+      return "ppcle_64";
+    }
+    if ("s390".equals(osArch)) {
+      return "s390_32";
+    }
+    if ("s390x".equals(osArch)) {
+      return "s390_64";
+    }
+
+    return UNKNOWN;
+  }
+
+  static String normalizeVM(final String javaVendor, final String javaVmName) {
+    if (javaVmName.contains("graalvm")) {
+      return "graalvm";
+    }
+    if (javaVendor.contains("oracle")) {
+      if (javaVmName.contains("openjdk")) {
+        return "oracle_openjdk";
+      } else {
+        return "oracle";
+      }
+    }
+    if (javaVendor.contains("adoptopenjdk")) {
+      return "adoptopenjdk";
+    }
+    if (javaVendor.contains("openj9")) {
+      return "openj9";
+    }
+    if (javaVendor.contains("azul")) {
+      if (javaVmName.contains("zing")) {
+        return "zing";
+      } else {
+        return "zulu";
+      }
+    }
+    if (javaVendor.contains("amazoncominc")) {
+      return "corretto";
+    }
+    if (javaVmName.contains("openjdk")) {
+      return "openjdk";
+    }
+
+    return "-" + javaVendor + "-" + javaVmName;
+  }
+
+  static String normalizeJavaVersion(final String javaVersion) {
+    // These are already normalized.
+    return System.getProperty(javaVersion);
+  }
+
+  private static String normalize(final String value) {
+    if (value == null) {
+      return "";
+    }
+    return System.getProperty(value).toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+  }
+}

--- a/src/test/java/net/consensys/orion/cmd/OrionArgumentsTest.java
+++ b/src/test/java/net/consensys/orion/cmd/OrionArgumentsTest.java
@@ -12,17 +12,14 @@
  */
 package net.consensys.orion.cmd;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.BufferedReader;
+import net.consensys.orion.utils.OrionInfo;
+
 import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -71,14 +68,11 @@ class OrionArgumentsTest {
   @Test
   void versionArgument() {
     final String[] args = {"-v"};
-
     final OrionArguments arguments = new OrionArguments(outStream, errStream, args);
-    final InputStream versionFile = OrionArguments.class.getResourceAsStream("/version.txt");
-    String version = "(development)";
-    if (versionFile != null) {
-      version = new BufferedReader(new InputStreamReader(versionFile, UTF_8)).lines().collect(Collectors.joining("\n"));
-    }
-    assertEquals(version + System.lineSeparator(), outContent.toString());
+
+    final String expectedVersion = OrionInfo.version();
+
+    assertEquals(expectedVersion + System.lineSeparator(), outContent.toString());
     assertTrue(arguments.argumentExit());
   }
 

--- a/src/test/java/net/consensys/orion/http/handler/VersionHandlerTest.java
+++ b/src/test/java/net/consensys/orion/http/handler/VersionHandlerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package net.consensys.orion.http.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+
+class VersionHandlerTest extends HandlerTest {
+
+  @Test
+  void handleVersionRequestSuccessfullyOnClientApi() throws Exception {
+    final Request request = new Request.Builder().get().url(clientBaseUrl + "/version").build();
+
+    final Response resp = httpClient.newCall(request).execute();
+    assertEquals(200, resp.code());
+    assertTrue(resp.body().string().matches("orion/.*?/.*?/.*"));
+  }
+
+  @Test
+  void versionCheckNotEnabledForNodeApi() throws Exception {
+    final Request request = new Request.Builder().get().url(nodeBaseUrl + "/version").build();
+
+    final Response resp = httpClient.newCall(request).execute();
+    assertEquals(404, resp.code());
+  }
+}


### PR DESCRIPTION
- Created a `OrionInfo` class that handles the version information for Orion
- Added a `VersionHandler` object to handle GET requests to `/version` (only on the Client API)
- Updated cli option to use `OrionInfo` when printing the version for `--version` command

The version string can be the following:
- `orion/v1.6.0/osx-x86_64/oracle_openjdk-java-11` when using a built version of Orion
- `orion/development/osx-x86_64/oracle_openjdk-java-11` when running it in the IDE for example

Fixes #349